### PR TITLE
Retrieve the block number that has to start an event specification scan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,5 +18,11 @@
 *.tar.gz
 *.rar
 
+# IDE Files #
+.idea
+
+# Build files #
+target/
+
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*

--- a/core/src/main/java/net/consensys/eventeum/chain/service/DefaultEventBlockManagementService.java
+++ b/core/src/main/java/net/consensys/eventeum/chain/service/DefaultEventBlockManagementService.java
@@ -53,18 +53,18 @@ public class DefaultEventBlockManagementService implements EventBlockManagementS
      * {@inheritDoc}
      */
     @Override
-    public BigInteger getLatestBlockForEvent(ContractEventSpecification eventSpec) {
+    public BigInteger getBlockNumberForScanEvent(ContractEventSpecification eventSpec) {
         final String eventSignature = Web3jUtil.getSignature(eventSpec);
         final BigInteger latestBlockNumber = latestBlocks.get(eventSignature);
 
         if (latestBlockNumber != null) {
-            return latestBlockNumber;
+            return latestBlockNumber.add(BigInteger.valueOf(1));
         }
 
         final ContractEventDetails contractEvent = eventStoreService.getLatestContractEvent(eventSignature);
 
         if (contractEvent != null) {
-            return contractEvent.getBlockNumber();
+            return contractEvent.getBlockNumber().add(BigInteger.valueOf(1));
         }
 
         return blockchainService.getCurrentBlockNumber();

--- a/core/src/main/java/net/consensys/eventeum/chain/service/EventBlockManagementService.java
+++ b/core/src/main/java/net/consensys/eventeum/chain/service/EventBlockManagementService.java
@@ -20,10 +20,10 @@ public interface EventBlockManagementService {
     void updateLatestBlock(String eventSpecHash, BigInteger blockNumber);
 
     /**
-     * Retrieve the latest block number that has been seen for a specified event specification.
+     * Retrieve the block number that has to start an event specification scan.
      *
      * @param eventSpec The event specification.
      * @return The latest block number that has been seen for a specified event specification.
      */
-    BigInteger getLatestBlockForEvent(ContractEventSpecification eventSpec);
+    BigInteger getBlockNumberForScanEvent(ContractEventSpecification eventSpec);
 }

--- a/core/src/main/java/net/consensys/eventeum/chain/service/Web3jService.java
+++ b/core/src/main/java/net/consensys/eventeum/chain/service/Web3jService.java
@@ -5,7 +5,6 @@ import net.consensys.eventeum.chain.service.strategy.BlockSubscriptionStrategy;
 import net.consensys.eventeum.chain.util.Web3jUtil;
 import net.consensys.eventeum.chain.service.domain.wrapper.Web3jTransactionReceipt;
 import net.consensys.eventeum.chain.service.factory.ContractEventDetailsFactory;
-import net.consensys.eventeum.dto.block.BlockDetails;
 import net.consensys.eventeum.dto.event.filter.ContractEventFilter;
 import net.consensys.eventeum.dto.event.filter.ContractEventSpecification;
 import net.consensys.eventeum.service.AsyncTaskService;
@@ -24,8 +23,6 @@ import rx.Subscription;
 import javax.annotation.PreDestroy;
 import java.io.IOException;
 import java.math.BigInteger;
-import java.util.Collection;
-import java.util.concurrent.ConcurrentLinkedQueue;
 
 /**
  * A BlockchainService implementating utilising the Web3j library.
@@ -163,6 +160,6 @@ public class Web3jService implements BlockchainService {
     }
 
     private BigInteger getStartBlockForEventSpec(ContractEventSpecification spec) {
-        return blockManagement.getLatestBlockForEvent(spec);
+        return blockManagement.getBlockNumberForScanEvent(spec);
     }
 }

--- a/core/src/test/java/net/consensys/eventeum/chain/service/DefaultEventBlockManagementServiceTest.java
+++ b/core/src/test/java/net/consensys/eventeum/chain/service/DefaultEventBlockManagementServiceTest.java
@@ -49,27 +49,27 @@ public class DefaultEventBlockManagementServiceTest {
     @Test
     public void testUpdateAndGetNoMatch() {
         underTest.updateLatestBlock(EVENT_SPEC_HASH, BigInteger.TEN);
-        final BigInteger result = underTest.getLatestBlockForEvent(EVENT_SPEC);
+        final BigInteger result = underTest.getBlockNumberForScanEvent(EVENT_SPEC);
 
-        assertEquals(BigInteger.TEN, result);
+        assertEquals(BigInteger.valueOf(11), result);
     }
 
     @Test
     public void testUpdateAndGetLowerMatch() {
         underTest.updateLatestBlock(EVENT_SPEC_HASH, BigInteger.ONE);
         underTest.updateLatestBlock(EVENT_SPEC_HASH, BigInteger.TEN);
-        final BigInteger result = underTest.getLatestBlockForEvent(EVENT_SPEC);
+        final BigInteger result = underTest.getBlockNumberForScanEvent(EVENT_SPEC);
 
-        assertEquals(BigInteger.TEN, result);
+        assertEquals(BigInteger.valueOf(11), result);
     }
 
     @Test
     public void testUpdateAndGetHigherMatch() {
         underTest.updateLatestBlock(EVENT_SPEC_HASH, BigInteger.TEN);
         underTest.updateLatestBlock(EVENT_SPEC_HASH, BigInteger.ONE);
-        final BigInteger result = underTest.getLatestBlockForEvent(EVENT_SPEC);
+        final BigInteger result = underTest.getBlockNumberForScanEvent(EVENT_SPEC);
 
-        assertEquals(BigInteger.TEN, result);
+        assertEquals(BigInteger.valueOf(11), result);
     }
 
     @Test
@@ -78,9 +78,9 @@ public class DefaultEventBlockManagementServiceTest {
         when(mockEventDetails.getBlockNumber()).thenReturn(BigInteger.ONE);
         when(mockEventStoreService.getLatestContractEvent(EVENT_SPEC_HASH)).thenReturn(mockEventDetails);
 
-        final BigInteger result = underTest.getLatestBlockForEvent(EVENT_SPEC);
+        final BigInteger result = underTest.getBlockNumberForScanEvent(EVENT_SPEC);
 
-        assertEquals(BigInteger.ONE, result);
+        assertEquals(BigInteger.valueOf(2), result);
     }
 
     @Test
@@ -88,7 +88,7 @@ public class DefaultEventBlockManagementServiceTest {
         when(mockEventStoreService.getLatestContractEvent(EVENT_SPEC_HASH)).thenReturn(null);
         when(mockBlockchainService.getCurrentBlockNumber()).thenReturn(BigInteger.valueOf(20));
 
-        final BigInteger result = underTest.getLatestBlockForEvent(EVENT_SPEC);
+        final BigInteger result = underTest.getBlockNumberForScanEvent(EVENT_SPEC);
 
         assertEquals(BigInteger.valueOf(20), result);
     }

--- a/core/src/test/java/net/consensys/eventeum/chain/service/Web3jServiceTest.java
+++ b/core/src/test/java/net/consensys/eventeum/chain/service/Web3jServiceTest.java
@@ -1,12 +1,10 @@
 package net.consensys.eventeum.chain.service;
 
 import net.consensys.eventeum.chain.service.domain.TransactionReceipt;
-import net.consensys.eventeum.chain.block.BlockListener;
 import net.consensys.eventeum.chain.service.domain.Log;
 import net.consensys.eventeum.chain.contract.ContractEventListener;
 import net.consensys.eventeum.chain.service.factory.ContractEventDetailsFactory;
 import net.consensys.eventeum.chain.service.strategy.BlockSubscriptionStrategy;
-import net.consensys.eventeum.dto.block.BlockDetails;
 import net.consensys.eventeum.dto.event.ContractEventDetails;
 import net.consensys.eventeum.dto.event.filter.ContractEventFilter;
 import net.consensys.eventeum.dto.event.filter.ContractEventSpecification;
@@ -20,7 +18,6 @@ import org.web3j.protocol.core.Request;
 import org.web3j.protocol.core.methods.request.EthFilter;
 import org.web3j.protocol.core.methods.response.*;
 import rx.Observable;
-import rx.subjects.PublishSubject;
 
 import java.io.IOException;
 import java.math.BigInteger;
@@ -64,7 +61,7 @@ public class Web3jServiceTest {
         mockContractEventDetails = mock(ContractEventDetails.class);
         mockBlockSubscriptionStrategy = mock(BlockSubscriptionStrategy.class);
 
-        when(mockBlockManagement.getLatestBlockForEvent(any(ContractEventSpecification.class))).thenReturn(BLOCK_NUMBER);
+        when(mockBlockManagement.getBlockNumberForScanEvent(any(ContractEventSpecification.class))).thenReturn(BLOCK_NUMBER);
 
         //Wire up getBlockNumber
         final Request<?, EthBlockNumber> mockRequest = mock(Request.class);


### PR DESCRIPTION
* Fix #17 issue 