### PR TITLE
Bug/bytes32 conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,7 @@ Eventeum can either be configured by:
 | BROADCASTER_MULTIINSTANCE | false | If multiple instances of eventeum are to be deployed in your system, this should be set to true so that the eventeum communicates added/removed filters to other instances, via kafka. |
 | BROADCASTER_HTTP CONTRACTEVENTSURL | | The http url for posting contract events (for HTTP broadcasting) |
 | BROADCASTER_HTTP BLOCKEVENTSURL | | The http url for posting block events (for HTTP broadcasting) |
+| BROADCASTER_BYTESTOASCII | false | If any bytes values within events should be converted to ascii (default is hex) |
 | ZOOKEEPER_ADDRESS | localhost:2181 | The zookeeper address |
 | KAFKA_ADDRESSES | localhost:9092 | Comma seperated list of kafka addresses |
 | KAFKA_TOPIC_CONTRACT_EVENTS | contract-events | The topic name for broadcast contract event messages |

--- a/core/src/main/java/net/consensys/eventeum/chain/config/NodeBeanRegistrationStrategy.java
+++ b/core/src/main/java/net/consensys/eventeum/chain/config/NodeBeanRegistrationStrategy.java
@@ -89,7 +89,7 @@ public class NodeBeanRegistrationStrategy {
         final BeanDefinitionBuilder builder = BeanDefinitionBuilder.genericBeanDefinition(
                 ContractEventDetailsFactoryFactoryBean.class);
 
-        builder.addPropertyValue("parameterConverter", new Web3jEventParameterConverter())
+        builder.addPropertyReference("parameterConverter", "web3jEventParameterConverter")
                 .addPropertyReference("eventConfirmationConfig", "eventConfirmationConfig")
                 .addPropertyValue("nodeName", node.getName());
 

--- a/core/src/main/java/net/consensys/eventeum/chain/converter/Web3jEventParameterConverter.java
+++ b/core/src/main/java/net/consensys/eventeum/chain/converter/Web3jEventParameterConverter.java
@@ -3,6 +3,7 @@ package net.consensys.eventeum.chain.converter;
 import net.consensys.eventeum.dto.event.parameter.EventParameter;
 import net.consensys.eventeum.dto.event.parameter.NumberParameter;
 import net.consensys.eventeum.dto.event.parameter.StringParameter;
+import net.consensys.eventeum.settings.EventeumSettings;
 import org.springframework.stereotype.Component;
 import org.web3j.abi.datatypes.Type;
 import org.web3j.crypto.Keys;
@@ -17,12 +18,14 @@ import java.util.Map;
  *
  * @author Craig Williams <craig.williams@consensys.net>
  */
-@Component
+@Component("web3jEventParameterConverter")
 public class Web3jEventParameterConverter implements EventParameterConverter<Type> {
 
     private Map<String, EventParameterConverter<Type>> typeConverters = new HashMap<String, EventParameterConverter<Type>>();
 
-    public Web3jEventParameterConverter() {
+    private EventeumSettings settings;
+
+    public Web3jEventParameterConverter(EventeumSettings settings) {
         typeConverters.put("address",
                 (type) -> new StringParameter(type.getTypeAsString(), Keys.toChecksumAddress(type.toString())));
         typeConverters.put("uint8",
@@ -32,14 +35,12 @@ public class Web3jEventParameterConverter implements EventParameterConverter<Typ
         typeConverters.put("int256",
                 (type) -> new NumberParameter(type.getTypeAsString(), (BigInteger) type.getValue()));
         typeConverters.put("bytes32",
-                (type) -> new StringParameter(type.getTypeAsString(),
-                        trim(new String((byte[]) type.getValue()))));
-        typeConverters.put("bytes32Hex",
-                (type) -> new StringParameter(type.getTypeAsString(),
-                        trim(Numeric.toHexString((byte[]) type.getValue()))));
+                (type) -> convertBytesType(type));
         typeConverters.put("string",
                 (type) -> new StringParameter(type.getTypeAsString(),
                         trim((String)type.getValue())));
+
+        this.settings = settings;
     }
 
     @Override
@@ -51,6 +52,16 @@ public class Web3jEventParameterConverter implements EventParameterConverter<Typ
         }
 
         return typeConverter.convert(toConvert);
+    }
+
+    private EventParameter convertBytesType(Type bytesType) {
+        if (settings.isBytesToAscii()) {
+            return new StringParameter(
+                    bytesType.getTypeAsString(), trim(new String((byte[]) bytesType.getValue())));
+        }
+
+        return new StringParameter(
+                bytesType.getTypeAsString(), trim(Numeric.toHexString((byte[]) bytesType.getValue())));
     }
 
     private String trim(String toTrim) {

--- a/core/src/main/java/net/consensys/eventeum/settings/EventeumSettings.java
+++ b/core/src/main/java/net/consensys/eventeum/settings/EventeumSettings.java
@@ -1,0 +1,16 @@
+package net.consensys.eventeum.settings;
+
+import lombok.Data;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+@Data
+public class EventeumSettings {
+
+    private boolean bytesToAscii;
+
+    public EventeumSettings(@Value("${broadcaster.bytesToAscii:false}") boolean bytesToAscii) {
+        this.bytesToAscii = bytesToAscii;
+    }
+}

--- a/core/src/main/resources/application.yml
+++ b/core/src/main/resources/application.yml
@@ -52,6 +52,7 @@ broadcaster:
       numBlocksToWait: 12
       numBlocksToWaitForMissingTx: 100
   multiInstance: false
+  bytesToAscii: false
 
 # For Kafka
 zookeeper:

--- a/core/src/test/java/net/consensys/eventeum/chain/converter/Web3jEventParameterConverterTest.java
+++ b/core/src/test/java/net/consensys/eventeum/chain/converter/Web3jEventParameterConverterTest.java
@@ -1,6 +1,7 @@
 package net.consensys.eventeum.chain.converter;
 
 import net.consensys.eventeum.dto.event.parameter.EventParameter;
+import net.consensys.eventeum.settings.EventeumSettings;
 import org.junit.Before;
 import org.junit.Test;
 import org.web3j.abi.datatypes.Address;
@@ -20,7 +21,7 @@ public class Web3jEventParameterConverterTest {
 
     @Before
     public void init() {
-        underTest = new Web3jEventParameterConverter();
+        underTest = new Web3jEventParameterConverter(new EventeumSettings(true));
     }
 
     @Test

--- a/server/src/test/java/net/consensys/eventeumserver/integrationtest/AsciiBytesIT.java
+++ b/server/src/test/java/net/consensys/eventeumserver/integrationtest/AsciiBytesIT.java
@@ -1,0 +1,53 @@
+package net.consensys.eventeumserver.integrationtest;
+
+import net.consensys.eventeum.dto.block.BlockDetails;
+import net.consensys.eventeum.dto.event.ContractEventDetails;
+import net.consensys.eventeum.dto.event.ContractEventStatus;
+import net.consensys.eventeum.dto.event.filter.ContractEventFilter;
+import net.consensys.eventeum.integration.eventstore.EventStore;
+import net.consensys.eventeum.model.LatestBlock;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.web3j.crypto.Keys;
+
+import java.math.BigInteger;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.Assert.assertEquals;
+
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(
+        properties = {"broadcaster.bytesToAscii=true"},
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+@TestPropertySource(locations="classpath:application-test-db.properties")
+public class AsciiBytesIT extends MainBroadcasterTests {
+
+    @Autowired
+    private EventStore eventStore;
+
+    @Test
+    public void testAsciiBytes() throws Exception {
+        final EventEmitter emitter = deployEventEmitterContract();
+
+        final ContractEventFilter registeredFilter = registerDummyEventFilter(emitter.getContractAddress());
+        emitter.emit(stringToBytes("BytesValue"), BigInteger.TEN, "StringValue").send();
+
+        waitForContractEventMessages(1);
+
+        assertEquals(1, getBroadcastContractEvents().size());
+
+        final ContractEventDetails eventDetails = getBroadcastContractEvents().get(0);
+
+        verifyDummyEventDetails(registeredFilter, eventDetails, ContractEventStatus.UNCONFIRMED,
+                "BytesValue", Keys.toChecksumAddress(CREDS.getAddress()), BigInteger.TEN, "StringValue");
+    }
+}

--- a/server/src/test/java/net/consensys/eventeumserver/integrationtest/BaseIntegrationTest.java
+++ b/server/src/test/java/net/consensys/eventeumserver/integrationtest/BaseIntegrationTest.java
@@ -57,6 +57,9 @@ public class BaseIntegrationTest {
 
     private static final String PARITY_VOLUME_PATH = "target/parity";
 
+    //"BytesValue" in hex
+    private static final String BYTES_VALUE_HEX = "0x427974657356616c756500000000000000000000000000000000000000000000";
+
     protected static final BigInteger GAS_PRICE = BigInteger.valueOf(22_000_000_000L);
     protected static final BigInteger GAS_LIMIT = BigInteger.valueOf(4_300_000);
 
@@ -293,8 +296,9 @@ public class BaseIntegrationTest {
 
     protected void verifyDummyEventDetails(ContractEventFilter registeredFilter,
                                          ContractEventDetails eventDetails, ContractEventStatus status) {
+
         verifyDummyEventDetails(registeredFilter, eventDetails, status,
-                "BytesValue", Keys.toChecksumAddress(CREDS.getAddress()), BigInteger.TEN, "StringValue");
+                BYTES_VALUE_HEX, Keys.toChecksumAddress(CREDS.getAddress()), BigInteger.TEN, "StringValue");
     }
 
     protected void verifyDummyEventDetails(ContractEventFilter registeredFilter,

--- a/server/src/test/java/net/consensys/eventeumserver/integrationtest/NodeRecoveryTests.java
+++ b/server/src/test/java/net/consensys/eventeumserver/integrationtest/NodeRecoveryTests.java
@@ -4,6 +4,7 @@ import net.consensys.eventeum.dto.event.ContractEventDetails;
 import net.consensys.eventeum.dto.event.ContractEventStatus;
 import net.consensys.eventeum.dto.event.filter.ContractEventFilter;
 import org.web3j.crypto.Keys;
+import org.web3j.utils.Numeric;
 
 import java.math.BigInteger;
 import java.util.UUID;
@@ -67,8 +68,18 @@ public class NodeRecoveryTests extends BaseKafkaIntegrationTest {
 
         final ContractEventDetails secondEventDetails = getBroadcastContractEvents().get(0);
 
-        verifyDummyEventDetails(registeredFilter, secondEventDetails, ContractEventStatus.UNCONFIRMED, valueOne,
-                Keys.toChecksumAddress(CREDS.getAddress()), BigInteger.valueOf(123), valueFour);
+        verifyDummyEventDetails(registeredFilter, secondEventDetails, ContractEventStatus.UNCONFIRMED,
+                toHexWithTrailingZeros(valueOne.getBytes(), 66), Keys.toChecksumAddress(CREDS.getAddress()), BigInteger.valueOf(123), valueFour);
+    }
+
+    private String toHexWithTrailingZeros(byte[] bytes, int length) {
+        String hex = Numeric.toHexString(bytes);
+
+        while (hex.length() != length) {
+            hex = hex + "0";
+        }
+
+        return hex;
     }
 
     private void restartParity(long timeToRecovery) throws Exception {


### PR DESCRIPTION
Fixed #47.  By default, broadcast bytes32 parameters are now in hex format rather than ascii.  This can be toggled by setting the broadcaster.bytesToAscii property.