### PR TITLE
Consider the contract address along with the event specification when…

### DIFF
--- a/core/src/main/java/net/consensys/eventeum/chain/service/DefaultEventBlockManagementService.java
+++ b/core/src/main/java/net/consensys/eventeum/chain/service/DefaultEventBlockManagementService.java
@@ -64,7 +64,8 @@ public class DefaultEventBlockManagementService implements EventBlockManagementS
             return latestBlockNumber;
         }
 
-        final Optional<ContractEventDetails> contractEvent = eventStoreService.getLatestContractEvent(eventSignature);
+        final Optional<ContractEventDetails> contractEvent =
+                eventStoreService.getLatestContractEvent(eventSignature, eventFilter.getContractAddress());
 
         if (contractEvent.isPresent()) {
             return contractEvent.get().getBlockNumber();

--- a/core/src/main/java/net/consensys/eventeum/integration/eventstore/EventStore.java
+++ b/core/src/main/java/net/consensys/eventeum/integration/eventstore/EventStore.java
@@ -14,7 +14,8 @@ import java.util.Optional;
  * @author Craig Williams <craig.williams@consensys.net>
  */
 public interface EventStore {
-    Page<ContractEventDetails> getContractEventsForSignature(String eventSignature, PageRequest pagination);
+    Page<ContractEventDetails> getContractEventsForSignature(
+            String eventSignature, String contractAddress, PageRequest pagination);
 
     Optional<LatestBlock> getLatestBlockForNode(String nodeName);
 

--- a/core/src/main/java/net/consensys/eventeum/integration/eventstore/db/DBEventStore.java
+++ b/core/src/main/java/net/consensys/eventeum/integration/eventstore/db/DBEventStore.java
@@ -46,9 +46,14 @@ public class DBEventStore implements SaveableEventStore {
     }
 
     @Override
-    public Page<ContractEventDetails> getContractEventsForSignature(String eventSignature, PageRequest pagination) {
+    public Page<ContractEventDetails> getContractEventsForSignature(
+            String eventSignature, String contractAddress, PageRequest pagination) {
 
-        final Query query = new Query(Criteria.where("eventSpecificationSignature").is(eventSignature))
+        final Query query = new Query(
+                Criteria.where("eventSpecificationSignature")
+                .is(eventSignature)
+                .and("address")
+                .is(contractAddress))
             .with(new Sort(Direction.DESC, "blockNumber"))
             .collation(Collation.of("en").numericOrderingEnabled());
 

--- a/core/src/main/java/net/consensys/eventeum/integration/eventstore/rest/RESTEventStore.java
+++ b/core/src/main/java/net/consensys/eventeum/integration/eventstore/rest/RESTEventStore.java
@@ -34,14 +34,16 @@ public class RESTEventStore implements EventStore {
     }
 
     @Override
-    public Page<ContractEventDetails> getContractEventsForSignature(String eventSignature, PageRequest pagination) {
+    public Page<ContractEventDetails> getContractEventsForSignature(
+            String eventSignature, String contractAddress, PageRequest pagination) {
 
         final Sort.Order firstOrder = pagination.getSort().iterator().next();
         return client.getContractEvents(pagination.getPageNumber(),
                                              pagination.getPageSize(),
                                              firstOrder.getProperty(),
                                              firstOrder.getDirection(),
-                                             eventSignature);
+                                             eventSignature,
+                                             contractAddress);
     }
 
     @Override

--- a/core/src/main/java/net/consensys/eventeum/integration/eventstore/rest/client/EventStoreClient.java
+++ b/core/src/main/java/net/consensys/eventeum/integration/eventstore/rest/client/EventStoreClient.java
@@ -20,7 +20,8 @@ public interface EventStoreClient {
             @RequestParam(value = "size") int pageSize,
             @RequestParam(value = "sort") String sortAttribute,
             @RequestParam(value = "dir") Sort.Direction sortDirection,
-            @RequestParam(value = "signature") String signature);
+            @RequestParam(value = "signature") String signature,
+            @RequestParam(value = "contractAddress") String contractAddress);
 
     @RequestMapping(method = RequestMethod.GET, value="${eventStore.latestBlockPath}")
     LatestBlock getLatestBlock(@RequestParam(value = "nodeName") String nodeName);

--- a/core/src/main/java/net/consensys/eventeum/service/DefaultEventStoreService.java
+++ b/core/src/main/java/net/consensys/eventeum/service/DefaultEventStoreService.java
@@ -29,14 +29,15 @@ public class DefaultEventStoreService implements EventStoreService {
      * @{inheritDoc}
      */
     @Override
-    public Optional<ContractEventDetails> getLatestContractEvent(String eventSignature) {
+    public Optional<ContractEventDetails> getLatestContractEvent(
+            String eventSignature, String contractAddress) {
         int page = eventStore.isPagingZeroIndexed() ? 0 : 1;
 
         final PageRequest pagination = new PageRequest(page,
                 1, new Sort(Sort.Direction.DESC, "blockNumber"));
 
         final Page<ContractEventDetails> eventsPage =
-                eventStore.getContractEventsForSignature(eventSignature, pagination);
+                eventStore.getContractEventsForSignature(eventSignature, contractAddress, pagination);
 
         if (eventsPage == null) {
             return Optional.empty();

--- a/core/src/main/java/net/consensys/eventeum/service/EventStoreService.java
+++ b/core/src/main/java/net/consensys/eventeum/service/EventStoreService.java
@@ -16,9 +16,10 @@ public interface EventStoreService {
      * Returns the contract event with the latest block, that matches the event signature.
      *
      * @param eventSignature The event signature
+     * @param contractAddress The event contract address
      * @return The event details
      */
-    Optional<ContractEventDetails> getLatestContractEvent(String eventSignature);
+    Optional<ContractEventDetails> getLatestContractEvent(String eventSignature, String contractAddress);
 
     /**
      * Returns the latest block, for the specified node.

--- a/core/src/test/java/net/consensys/eventeum/chain/service/DefaultEventBlockManagementServiceTest.java
+++ b/core/src/test/java/net/consensys/eventeum/chain/service/DefaultEventBlockManagementServiceTest.java
@@ -24,6 +24,8 @@ public class DefaultEventBlockManagementServiceTest {
 
     private static final String EVENT_SPEC_HASH = "0x4d44a3f7bbdc3ab16cf28ad5234f38b7464ff912da473754ab39f0f97692eded";
 
+    private static final String CONTRACT_ADDRESS = "0xd94a9d6733a64cecdcc8ca01da72554b4d883a47";
+
     private static final ContractEventSpecification EVENT_SPEC;
 
     private static final ContractEventFilter EVENT_FILTER;
@@ -48,6 +50,7 @@ public class DefaultEventBlockManagementServiceTest {
         EVENT_FILTER = new ContractEventFilter();
         EVENT_FILTER.setNode(Constants.DEFAULT_NODE_NAME);
         EVENT_FILTER.setEventSpecification(EVENT_SPEC);
+        EVENT_FILTER.setContractAddress(CONTRACT_ADDRESS);
 
         EVENT_SPEC.setNonIndexedParameterDefinitions(
                 Arrays.asList(new ParameterDefinition(2, ParameterType.BYTES32)));
@@ -97,7 +100,7 @@ public class DefaultEventBlockManagementServiceTest {
     public void testGetNoLocalMatchButHitInEventStore() {
         final ContractEventDetails mockEventDetails = mock(ContractEventDetails.class);
         when(mockEventDetails.getBlockNumber()).thenReturn(BigInteger.ONE);
-        when(mockEventStoreService.getLatestContractEvent(EVENT_SPEC_HASH)).thenReturn(Optional.of(mockEventDetails));
+        when(mockEventStoreService.getLatestContractEvent(EVENT_SPEC_HASH, CONTRACT_ADDRESS)).thenReturn(Optional.of(mockEventDetails));
 
         final BigInteger result = underTest.getLatestBlockForEvent(EVENT_FILTER);
 
@@ -106,9 +109,9 @@ public class DefaultEventBlockManagementServiceTest {
 
     @Test
     public void testGetNoLocalMatchAndNoHitInEventStore() {
-        when(mockEventStoreService.getLatestContractEvent(EVENT_SPEC_HASH)).thenReturn(null);
+        when(mockEventStoreService.getLatestContractEvent(EVENT_SPEC_HASH, CONTRACT_ADDRESS)).thenReturn(null);
         when(mockBlockchainService.getCurrentBlockNumber()).thenReturn(BigInteger.valueOf(20));
-        when(mockEventStoreService.getLatestContractEvent(EVENT_SPEC_HASH)).thenReturn(Optional.empty());
+        when(mockEventStoreService.getLatestContractEvent(EVENT_SPEC_HASH, CONTRACT_ADDRESS)).thenReturn(Optional.empty());
 
         final BigInteger result = underTest.getLatestBlockForEvent(EVENT_FILTER);
 

--- a/core/src/test/java/net/consensys/eventeum/service/DefaultEventStoreServiceTest.java
+++ b/core/src/test/java/net/consensys/eventeum/service/DefaultEventStoreServiceTest.java
@@ -22,7 +22,9 @@ import static org.mockito.Mockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class DefaultEventStoreServiceTest {
 
-    private static final String EVENT_SIGNATURE = "signture";
+    private static final String EVENT_SIGNATURE = "signature";
+
+    private static final String CONTRACT_ADDRESS = "0xd94a9d6733a64cecdcc8ca01da72554b4d883a47";
 
     private DefaultEventStoreService underTest;
 
@@ -47,23 +49,23 @@ public class DefaultEventStoreServiceTest {
     public void testGetLatestContractEvent() {
         when(mockPage.getContent()).thenReturn(Arrays.asList(mockEventDetails1, mockEventDetails2));
         when(mockEventStore.getContractEventsForSignature(
-                eq(EVENT_SIGNATURE), any(PageRequest.class))).thenReturn(mockPage);
-        assertEquals(mockEventDetails1, underTest.getLatestContractEvent(EVENT_SIGNATURE).get());
+                eq(EVENT_SIGNATURE), eq(CONTRACT_ADDRESS), any(PageRequest.class))).thenReturn(mockPage);
+        assertEquals(mockEventDetails1, underTest.getLatestContractEvent(EVENT_SIGNATURE, CONTRACT_ADDRESS).get());
     }
 
     @Test
     public void testGetLatestContractEventNullEvents() {
         when(mockPage.getContent()).thenReturn(null);
         when(mockEventStore.getContractEventsForSignature(
-                eq(EVENT_SIGNATURE), any(PageRequest.class))).thenReturn(mockPage);
-        assertEquals(false, underTest.getLatestContractEvent(EVENT_SIGNATURE).isPresent());
+                eq(EVENT_SIGNATURE), eq(CONTRACT_ADDRESS), any(PageRequest.class))).thenReturn(mockPage);
+        assertEquals(false, underTest.getLatestContractEvent(EVENT_SIGNATURE, CONTRACT_ADDRESS).isPresent());
     }
 
     @Test
     public void testGetLatestContractEventEmptyEvents() {
         when(mockPage.getContent()).thenReturn(new ArrayList<>());
         when(mockEventStore.getContractEventsForSignature(
-                eq(EVENT_SIGNATURE), any(PageRequest.class))).thenReturn(mockPage);
-        assertEquals(false, underTest.getLatestContractEvent(EVENT_SIGNATURE).isPresent());
+                eq(EVENT_SIGNATURE), eq(CONTRACT_ADDRESS), any(PageRequest.class))).thenReturn(mockPage);
+        assertEquals(false, underTest.getLatestContractEvent(EVENT_SIGNATURE, CONTRACT_ADDRESS).isPresent());
     }
 }

--- a/server/src/test/java/net/consensys/eventeumserver/integrationtest/BroadcasterDBEventStoreIT.java
+++ b/server/src/test/java/net/consensys/eventeumserver/integrationtest/BroadcasterDBEventStoreIT.java
@@ -85,7 +85,7 @@ public class BroadcasterDBEventStoreIT extends MainBroadcasterTests {
         Thread.sleep(1000);
 
         List<ContractEventDetails> savedEvents = eventStore.getContractEventsForSignature(
-            eventDetails.getEventSpecificationSignature(), PageRequest.of(0, 100000)).getContent();
+            eventDetails.getEventSpecificationSignature(), emitter.getContractAddress(), PageRequest.of(0, 100000)).getContent();
 
         assertEquals(1, savedEvents.size());
         assertEquals(eventDetails, savedEvents.get(0));

--- a/server/src/test/java/net/consensys/eventeumserver/integrationtest/EventStoreFactoryConfig.java
+++ b/server/src/test/java/net/consensys/eventeumserver/integrationtest/EventStoreFactoryConfig.java
@@ -62,7 +62,8 @@ public class EventStoreFactoryConfig {
                     }
 
                     @Override
-                    public Page<ContractEventDetails> getContractEventsForSignature(String eventSignature, PageRequest pagination) {
+                    public Page<ContractEventDetails> getContractEventsForSignature(
+                            String eventSignature, String contractAddress, PageRequest pagination) {
                         return null;
                     }
 

--- a/server/src/test/java/net/consensys/eventeumserver/integrationtest/FromBlockDBEventStoreIT.java
+++ b/server/src/test/java/net/consensys/eventeumserver/integrationtest/FromBlockDBEventStoreIT.java
@@ -35,6 +35,8 @@ public class FromBlockDBEventStoreIT extends BaseFromBlockIntegrationTest {
         repo.save(createContractEventDetails(filter.getEventSpecification(), BigInteger.valueOf(1002)));
         repo.save(createContractEventDetails(filter.getEventSpecification(), BigInteger.valueOf(2004)));
         repo.save(createContractEventDetails(filter.getEventSpecification(), BigInteger.valueOf(209)));
+        repo.save(createContractEventDetails(filter.getEventSpecification(),
+                BigInteger.valueOf(2005), "0xa8c985f41f10a084d353e47f2529f35c4ba13ca9"));
 
         registerEventFilter(filter);
 
@@ -43,9 +45,16 @@ public class FromBlockDBEventStoreIT extends BaseFromBlockIntegrationTest {
 
     private ContractEventDetails createContractEventDetails(ContractEventSpecification eventSpec, BigInteger blockNumber) {
 
+        return createContractEventDetails(eventSpec, blockNumber, FAKE_CONTRACT_ADDRESS);
+    }
+
+    private ContractEventDetails createContractEventDetails(
+            ContractEventSpecification eventSpec, BigInteger blockNumber, String contractAddress) {
+
         final ContractEventDetails eventDetails = new ContractEventDetails();
         eventDetails.setBlockNumber(blockNumber);
         eventDetails.setEventSpecificationSignature(Web3jUtil.getSignature(eventSpec));
+        eventDetails.setAddress(contractAddress);
 
         return eventDetails;
     }


### PR DESCRIPTION
… calculating the start block number.  This fixes issues with the start block if the same contract is deployed multiple times or on different nodes.