### PR TITLE
Bug/contract creation address

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,6 +360,9 @@ When a new transaction that matches a transaction monitor is mined, a JSON messa
 }
 ```
 
+#### Contract Creation Transaction
+If the transaction is a contract creation transaction, then the `contractAddress` value will be set to the address of the newly deployed smart contract.
+
 #### Transaction Event Statuses
 
 A broadcast transaction event can have the following statuses:

--- a/core/src/main/java/net/consensys/eventeum/chain/factory/DefaultTransactionDetailsFactory.java
+++ b/core/src/main/java/net/consensys/eventeum/chain/factory/DefaultTransactionDetailsFactory.java
@@ -5,6 +5,7 @@ import net.consensys.eventeum.dto.transaction.TransactionDetails;
 import net.consensys.eventeum.dto.transaction.TransactionStatus;
 import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Component;
+import org.web3j.crypto.Keys;
 
 @Component
 public class DefaultTransactionDetailsFactory implements TransactionDetailsFactory {
@@ -20,6 +21,10 @@ public class DefaultTransactionDetailsFactory implements TransactionDetailsFacto
 
         transactionDetails.setNodeName(nodeName);
         transactionDetails.setStatus(status);
+
+        if (transaction.getCreates() != null) {
+            transactionDetails.setContractAddress(Keys.toChecksumAddress(transaction.getCreates()));
+        }
 
         return transactionDetails;
     }

--- a/core/src/main/java/net/consensys/eventeum/dto/transaction/TransactionDetails.java
+++ b/core/src/main/java/net/consensys/eventeum/dto/transaction/TransactionDetails.java
@@ -22,6 +22,7 @@ public class TransactionDetails {
     private String to;
     private String value;
     private String nodeName;
+    private String contractAddress;
 
     private TransactionStatus status;
 }


### PR DESCRIPTION
Fixes #73 

Added a contractAddress field to broadcast transactions that is set to created contract address for contract creation transactions.