### PR TITLE
Pass Block to BlockListener's rather than BlockDetails.  

### DIFF
--- a/core/src/main/java/net/consensys/eventeum/chain/block/BlockListener.java
+++ b/core/src/main/java/net/consensys/eventeum/chain/block/BlockListener.java
@@ -1,5 +1,6 @@
 package net.consensys.eventeum.chain.block;
 
+import net.consensys.eventeum.chain.service.domain.Block;
 import net.consensys.eventeum.dto.block.BlockDetails;
 
 /**
@@ -12,7 +13,7 @@ public interface BlockListener {
     /**
      * Called when a new block is detected fron the ethereum node.
      *
-     * @param blockDetails The details of the new block.
+     * @param block The new block
      */
-    void onBlock(BlockDetails blockDetails);
+    void onBlock(Block block);
 }

--- a/core/src/main/java/net/consensys/eventeum/chain/block/BroadcastingBlockListener.java
+++ b/core/src/main/java/net/consensys/eventeum/chain/block/BroadcastingBlockListener.java
@@ -1,9 +1,14 @@
 package net.consensys.eventeum.chain.block;
 
+import lombok.AllArgsConstructor;
+import net.consensys.eventeum.chain.factory.BlockDetailsFactory;
+import net.consensys.eventeum.chain.service.domain.Block;
 import net.consensys.eventeum.dto.block.BlockDetails;
 import net.consensys.eventeum.integration.broadcast.blockchain.BlockchainEventBroadcaster;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import org.web3j.protocol.core.methods.response.EthBlock;
+import org.web3j.utils.Numeric;
 
 /**
  * A block listener that broadcasts the block details via the configured broadcaster.
@@ -11,17 +16,17 @@ import org.springframework.stereotype.Component;
  * @author Craig Williams <craig.williams@consensys.net>
  */
 @Component
+@AllArgsConstructor
 public class BroadcastingBlockListener implements BlockListener {
 
     private BlockchainEventBroadcaster eventBroadcaster;
 
-    @Autowired
-    public BroadcastingBlockListener(BlockchainEventBroadcaster eventBroadcaster) {
-        this.eventBroadcaster = eventBroadcaster;
-    }
+    private BlockDetailsFactory blockDetailsFactory;
 
     @Override
-    public void onBlock(BlockDetails blockDetails) {
-        eventBroadcaster.broadcastNewBlock(blockDetails);
+    public void onBlock(Block block) {
+        eventBroadcaster.broadcastNewBlock(blockDetailsFactory.createBlockDetails(block));
     }
+
+
 }

--- a/core/src/main/java/net/consensys/eventeum/chain/block/EventStoreLatestBlockUpdater.java
+++ b/core/src/main/java/net/consensys/eventeum/chain/block/EventStoreLatestBlockUpdater.java
@@ -1,5 +1,7 @@
 package net.consensys.eventeum.chain.block;
 
+import net.consensys.eventeum.chain.factory.BlockDetailsFactory;
+import net.consensys.eventeum.chain.service.domain.Block;
 import net.consensys.eventeum.dto.block.BlockDetails;
 import net.consensys.eventeum.integration.eventstore.SaveableEventStore;
 import net.consensys.eventeum.model.LatestBlock;
@@ -16,13 +18,17 @@ public class EventStoreLatestBlockUpdater implements BlockListener {
 
     private SaveableEventStore saveableEventStore;
 
+    private BlockDetailsFactory blockDetailsFactory;
+
     @Autowired
-    public EventStoreLatestBlockUpdater(SaveableEventStore saveableEventStore) {
+    public EventStoreLatestBlockUpdater(
+            SaveableEventStore saveableEventStore, BlockDetailsFactory blockDetailsFactory) {
         this.saveableEventStore = saveableEventStore;
+        this.blockDetailsFactory = blockDetailsFactory;
     }
 
     @Override
-    public void onBlock(BlockDetails blockDetails) {
-        saveableEventStore.save(new LatestBlock(blockDetails));
+    public void onBlock(Block block) {
+        saveableEventStore.save(new LatestBlock(blockDetailsFactory.createBlockDetails(block)));
     }
 }

--- a/core/src/main/java/net/consensys/eventeum/chain/block/LoggingBlockListener.java
+++ b/core/src/main/java/net/consensys/eventeum/chain/block/LoggingBlockListener.java
@@ -1,5 +1,6 @@
 package net.consensys.eventeum.chain.block;
 
+import net.consensys.eventeum.chain.service.domain.Block;
 import net.consensys.eventeum.dto.block.BlockDetails;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -16,7 +17,7 @@ public class LoggingBlockListener implements BlockListener {
     private static final Logger logger = LoggerFactory.getLogger(LoggingBlockListener.class);
 
     @Override
-    public void onBlock(BlockDetails blockDetails) {
-        logger.info(String.format("New block mined. Hash: %s, Number: %s", blockDetails.getHash(), blockDetails.getNumber()));
+    public void onBlock(Block block) {
+        logger.info(String.format("New block mined. Hash: %s, Number: %s", block.getHash(), block.getNumber()));
     }
 }

--- a/core/src/main/java/net/consensys/eventeum/chain/factory/BlockDetailsFactory.java
+++ b/core/src/main/java/net/consensys/eventeum/chain/factory/BlockDetailsFactory.java
@@ -1,0 +1,9 @@
+package net.consensys.eventeum.chain.factory;
+
+import net.consensys.eventeum.chain.service.domain.Block;
+import net.consensys.eventeum.dto.block.BlockDetails;
+
+public interface BlockDetailsFactory {
+
+    BlockDetails createBlockDetails(Block block);
+}

--- a/core/src/main/java/net/consensys/eventeum/chain/factory/DefaultBlockDetailsFactory.java
+++ b/core/src/main/java/net/consensys/eventeum/chain/factory/DefaultBlockDetailsFactory.java
@@ -1,0 +1,22 @@
+package net.consensys.eventeum.chain.factory;
+
+import net.consensys.eventeum.chain.service.domain.Block;
+import net.consensys.eventeum.dto.block.BlockDetails;
+import org.springframework.stereotype.Component;
+import org.web3j.utils.Numeric;
+
+@Component
+public class DefaultBlockDetailsFactory implements BlockDetailsFactory {
+
+    @Override
+    public BlockDetails createBlockDetails(Block block) {
+        final BlockDetails blockDetails = new BlockDetails();
+
+        blockDetails.setNumber(block.getNumber());
+        blockDetails.setHash(block.getHash());
+        blockDetails.setTimestamp(block.getTimestamp());
+        blockDetails.setNodeName(block.getNodeName());
+
+        return blockDetails;
+    }
+}

--- a/core/src/main/java/net/consensys/eventeum/chain/service/Web3jService.java
+++ b/core/src/main/java/net/consensys/eventeum/chain/service/Web3jService.java
@@ -192,7 +192,7 @@ public class Web3jService implements BlockchainService {
                 return Optional.empty();
             }
 
-            return Optional.of(new Web3jBlock(blockResponse.getBlock()));
+            return Optional.of(new Web3jBlock(blockResponse.getBlock(), nodeName));
         } catch (IOException e) {
             throw new BlockchainException("Error when obtaining block with hash: " + blockHash, e);
         }

--- a/core/src/main/java/net/consensys/eventeum/chain/service/domain/Block.java
+++ b/core/src/main/java/net/consensys/eventeum/chain/service/domain/Block.java
@@ -1,15 +1,14 @@
 package net.consensys.eventeum.chain.service.domain;
 
-import org.web3j.protocol.core.methods.response.EthBlock;
-
+import java.math.BigInteger;
 import java.util.List;
 
 public interface Block {
 
-    String getNumber();
+    BigInteger getNumber();
     String getHash();
     String getParentHash();
-    String getNonce();
+    BigInteger getNonce();
     String getSha3Uncles();
     String getLogsBloom();
     String getTransactionsRoot();
@@ -18,15 +17,18 @@ public interface Block {
     String getAuthor();
     String getMiner();
     String getMixHash();
-    String getDifficulty();
-    String getTotalDifficulty();
+    BigInteger getDifficulty();
+    BigInteger getTotalDifficulty();
     String getExtraData();
-    String getSize();
-    String getGasLimit();
-    String getGasUsed();
-    String getTimestamp();
+    BigInteger getSize();
+    BigInteger getGasLimit();
+    BigInteger getGasUsed();
+    BigInteger getTimestamp();
     List<Transaction> getTransactions();
     List<String> getUncles();
     List<String> getSealFields();
+
+    //Eventeum specific
+    String getNodeName();
 }
 

--- a/core/src/main/java/net/consensys/eventeum/chain/service/strategy/AbstractBlockSubscriptionStrategy.java
+++ b/core/src/main/java/net/consensys/eventeum/chain/service/strategy/AbstractBlockSubscriptionStrategy.java
@@ -3,6 +3,7 @@ package net.consensys.eventeum.chain.service.strategy;
 import io.reactivex.disposables.Disposable;
 import lombok.extern.slf4j.Slf4j;
 import net.consensys.eventeum.chain.block.BlockListener;
+import net.consensys.eventeum.chain.service.domain.Block;
 import net.consensys.eventeum.dto.block.BlockDetails;
 import net.consensys.eventeum.integration.eventstore.EventStore;
 import net.consensys.eventeum.model.LatestBlock;
@@ -63,13 +64,13 @@ public abstract class AbstractBlockSubscriptionStrategy<T> implements BlockSubsc
     protected void triggerListeners(T blockObject) {
         lock.lock();
         try {
-            blockListeners.forEach(listener -> triggerListener(listener, convertToBlockDetails(blockObject)));
+            blockListeners.forEach(listener -> triggerListener(listener, convertToEventeumBlock(blockObject)));
         } finally {
             lock.unlock();
         }
     }
 
-    protected void triggerListener(BlockListener listener, BlockDetails block) {
+    protected void triggerListener(BlockListener listener, Block block) {
         try {
             listener.onBlock(block);
         } catch(Throwable t) {
@@ -81,6 +82,6 @@ public abstract class AbstractBlockSubscriptionStrategy<T> implements BlockSubsc
         return eventStoreService.getLatestBlock(nodeName);
     }
 
-    abstract BlockDetails convertToBlockDetails(T blockObject);
+    abstract Block convertToEventeumBlock(T blockObject);
 
 }

--- a/core/src/main/java/net/consensys/eventeum/chain/service/strategy/PollingBlockSubscriptionStrategy.java
+++ b/core/src/main/java/net/consensys/eventeum/chain/service/strategy/PollingBlockSubscriptionStrategy.java
@@ -1,6 +1,8 @@
 package net.consensys.eventeum.chain.service.strategy;
 
 import io.reactivex.disposables.Disposable;
+import net.consensys.eventeum.chain.service.domain.Block;
+import net.consensys.eventeum.chain.service.domain.wrapper.Web3jBlock;
 import net.consensys.eventeum.dto.block.BlockDetails;
 import net.consensys.eventeum.model.LatestBlock;
 import net.consensys.eventeum.service.EventStoreService;
@@ -24,11 +26,11 @@ public class PollingBlockSubscriptionStrategy extends AbstractBlockSubscriptionS
         if (latestBlock.isPresent()) {
             final DefaultBlockParameter blockParam = DefaultBlockParameter.valueOf(latestBlock.get().getNumber());
 
-            blockSubscription = web3j.replayPastAndFutureBlocksFlowable(blockParam, false)
+            blockSubscription = web3j.replayPastAndFutureBlocksFlowable(blockParam, true)
                     .subscribe(block -> { triggerListeners(block); });
 
         } else {
-            blockSubscription = web3j.blockFlowable(false).subscribe(block -> {
+            blockSubscription = web3j.blockFlowable(true).subscribe(block -> {
                 triggerListeners(block);
             });
         }
@@ -37,15 +39,7 @@ public class PollingBlockSubscriptionStrategy extends AbstractBlockSubscriptionS
     }
 
     @Override
-    BlockDetails convertToBlockDetails(EthBlock blockObject) {
-        final EthBlock.Block block = blockObject.getBlock();
-        final BlockDetails blockDetails = new BlockDetails();
-
-        blockDetails.setNumber(block.getNumber());
-        blockDetails.setHash(block.getHash());
-        blockDetails.setTimestamp(block.getTimestamp());
-        blockDetails.setNodeName(nodeName);
-
-        return blockDetails;
+    Block convertToEventeumBlock(EthBlock blockObject) {
+        return new Web3jBlock(blockObject.getBlock(), nodeName);
     }
 }

--- a/core/src/main/java/net/consensys/eventeum/config/CustomEventStoreConfiguration.java
+++ b/core/src/main/java/net/consensys/eventeum/config/CustomEventStoreConfiguration.java
@@ -4,6 +4,7 @@ import net.consensys.eventeum.chain.block.BlockListener;
 import net.consensys.eventeum.chain.block.EventStoreLatestBlockUpdater;
 import net.consensys.eventeum.chain.contract.ContractEventListener;
 import net.consensys.eventeum.chain.contract.EventStoreContractEventUpdater;
+import net.consensys.eventeum.chain.factory.BlockDetailsFactory;
 import net.consensys.eventeum.factory.EventStoreFactory;
 import net.consensys.eventeum.integration.eventstore.SaveableEventStore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
@@ -27,7 +28,8 @@ public class CustomEventStoreConfiguration {
     }
 
     @Bean
-    public BlockListener eventStoreLatestBlockUpdater(SaveableEventStore eventStore) {
-        return new EventStoreLatestBlockUpdater(eventStore);
+    public BlockListener eventStoreLatestBlockUpdater(
+            SaveableEventStore eventStore, BlockDetailsFactory blockDetailsFactory) {
+        return new EventStoreLatestBlockUpdater(eventStore, blockDetailsFactory);
     }
 }

--- a/core/src/main/java/net/consensys/eventeum/config/EventStoreConfiguration.java
+++ b/core/src/main/java/net/consensys/eventeum/config/EventStoreConfiguration.java
@@ -4,6 +4,7 @@ import net.consensys.eventeum.chain.block.BlockListener;
 import net.consensys.eventeum.chain.block.EventStoreLatestBlockUpdater;
 import net.consensys.eventeum.chain.contract.ContractEventListener;
 import net.consensys.eventeum.chain.contract.EventStoreContractEventUpdater;
+import net.consensys.eventeum.chain.factory.BlockDetailsFactory;
 import net.consensys.eventeum.factory.EventStoreFactory;
 import net.consensys.eventeum.integration.eventstore.EventStore;
 import net.consensys.eventeum.integration.eventstore.SaveableEventStore;
@@ -46,8 +47,9 @@ public class EventStoreConfiguration {
          }
 
          @Bean
-         public BlockListener eventStoreLatestBlockUpdater(SaveableEventStore eventStore) {
-             return new EventStoreLatestBlockUpdater(eventStore);
+         public BlockListener eventStoreLatestBlockUpdater(
+                 SaveableEventStore eventStore, BlockDetailsFactory blockDetailsFactory) {
+             return new EventStoreLatestBlockUpdater(eventStore, blockDetailsFactory);
          }
      }
 
@@ -70,8 +72,9 @@ public class EventStoreConfiguration {
         }
 
         @Bean
-        public BlockListener eventStoreLatestBlockUpdater(SaveableEventStore eventStore) {
-            return new EventStoreLatestBlockUpdater(eventStore);
+        public BlockListener eventStoreLatestBlockUpdater(
+                SaveableEventStore eventStore, BlockDetailsFactory blockDetailsFactory) {
+            return new EventStoreLatestBlockUpdater(eventStore, blockDetailsFactory);
         }
     }
 

--- a/core/src/test/java/net/consensys/eventeum/chain/block/BroadcastingBlockListenerTest.java
+++ b/core/src/test/java/net/consensys/eventeum/chain/block/BroadcastingBlockListenerTest.java
@@ -1,12 +1,20 @@
 package net.consensys.eventeum.chain.block;
 
+import net.consensys.eventeum.chain.factory.DefaultBlockDetailsFactory;
+import net.consensys.eventeum.chain.service.domain.Block;
+import net.consensys.eventeum.chain.service.domain.wrapper.Web3jBlock;
 import net.consensys.eventeum.dto.block.BlockDetails;
 import net.consensys.eventeum.integration.broadcast.blockchain.BlockchainEventBroadcaster;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.web3j.utils.Numeric;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
+import java.math.BigInteger;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.*;
 
 public class BroadcastingBlockListenerTest {
 
@@ -18,14 +26,18 @@ public class BroadcastingBlockListenerTest {
     public void init() {
         mockBroadcaster = mock(BlockchainEventBroadcaster.class);
 
-        underTest = new BroadcastingBlockListener(mockBroadcaster);
+        underTest = new BroadcastingBlockListener(mockBroadcaster, new DefaultBlockDetailsFactory());
     }
 
     @Test
     public void testOnBlock() {
-        final BlockDetails blockDetails = new BlockDetails();
-        underTest.onBlock(blockDetails);
+        final Block block = Mockito.mock(Block.class);
+        when(block.getNumber()).thenReturn(BigInteger.TEN);
+        underTest.onBlock(block);
 
-        verify(mockBroadcaster).broadcastNewBlock(blockDetails);
+        ArgumentCaptor<BlockDetails> captor = ArgumentCaptor.forClass(BlockDetails.class);
+        verify(mockBroadcaster).broadcastNewBlock(captor.capture());
+
+        assertEquals(BigInteger.TEN, captor.getValue().getNumber());
     }
 }

--- a/core/src/test/java/net/consensys/eventeum/chain/block/EventConfirmationBlockListenerTest.java
+++ b/core/src/test/java/net/consensys/eventeum/chain/block/EventConfirmationBlockListenerTest.java
@@ -1,5 +1,6 @@
 package net.consensys.eventeum.chain.block;
 
+import net.consensys.eventeum.chain.service.domain.Block;
 import net.consensys.eventeum.chain.service.domain.TransactionReceipt;
 import net.consensys.eventeum.chain.config.EventConfirmationConfig;
 import net.consensys.eventeum.chain.service.BlockchainService;
@@ -12,6 +13,7 @@ import net.consensys.eventeum.service.AsyncTaskService;
 import net.consensys.eventeum.testutils.DummyAsyncTaskService;
 import org.junit.Before;
 import org.junit.Test;
+import org.web3j.utils.Numeric;
 
 import java.math.BigInteger;
 import java.util.Arrays;
@@ -124,11 +126,11 @@ public class EventConfirmationBlockListenerTest {
         expectInvalidation();
     }
 
-    private BlockDetails createBlockDetails(int blockNumber) {
-        final BlockDetails blockDetails = mock(BlockDetails.class);
-        when(blockDetails.getNumber()).thenReturn(BigInteger.valueOf(blockNumber));
+    private Block createBlockDetails(int blockNumber) {
+        final Block block = mock(Block.class);
+        when(block.getNumber()).thenReturn(BigInteger.valueOf(blockNumber));
 
-        return blockDetails;
+        return block;
     }
 
     private void wireLog() {

--- a/core/src/test/java/net/consensys/eventeum/chain/service/strategy/PollingBlockchainSubscriptionStrategyTest.java
+++ b/core/src/test/java/net/consensys/eventeum/chain/service/strategy/PollingBlockchainSubscriptionStrategyTest.java
@@ -4,6 +4,7 @@ import io.reactivex.disposables.Disposable;
 import io.reactivex.processors.PublishProcessor;
 import net.consensys.eventeum.chain.block.BlockListener;
 import net.consensys.eventeum.chain.service.Web3jService;
+import net.consensys.eventeum.chain.service.domain.Block;
 import net.consensys.eventeum.dto.block.BlockDetails;
 import net.consensys.eventeum.service.EventStoreService;
 import net.consensys.eventeum.testutils.DummyAsyncTaskService;
@@ -55,7 +56,7 @@ public class PollingBlockchainSubscriptionStrategyTest {
         when(mockEthBlock.getBlock()).thenReturn(mockBlock);
 
         blockPublishProcessor = PublishProcessor.create();
-        when(mockWeb3j.blockFlowable(false)).thenReturn(blockPublishProcessor);
+        when(mockWeb3j.blockFlowable(true)).thenReturn(blockPublishProcessor);
 
         underTest = new PollingBlockSubscriptionStrategy(mockWeb3j, NODE_NAME, mockEventStoreService);
     }
@@ -81,15 +82,15 @@ public class PollingBlockchainSubscriptionStrategyTest {
     @Test
     public void testAddBlockListener() {
         underTest.subscribe();
-        final BlockDetails blockDetails = doRegisterBlockListenerAndTrigger();
-        assertNotNull(blockDetails);
+        final Block block = doRegisterBlockListenerAndTrigger();
+        assertNotNull(block);
     }
 
     @Test
     public void testRemoveBlockListener() {
         underTest.subscribe();
-        final BlockDetails blockDetails = doRegisterBlockListenerAndTrigger();
-        assertNotNull(blockDetails);
+        final Block block = doRegisterBlockListenerAndTrigger();
+        assertNotNull(block);
 
         reset(mockBlockListener);
         underTest.removeBlockListener(mockBlockListener);
@@ -102,43 +103,43 @@ public class PollingBlockchainSubscriptionStrategyTest {
     @Test
     public void testBlockHashPassedToListenerIsCorrect() {
         underTest.subscribe();
-        final BlockDetails blockDetails = doRegisterBlockListenerAndTrigger();
+        final Block block = doRegisterBlockListenerAndTrigger();
 
-        assertEquals(BLOCK_HASH, blockDetails.getHash());
+        assertEquals(BLOCK_HASH, block.getHash());
     }
 
     @Test
     public void testBlockNumberPassedToListenerIsCorrect() {
         underTest.subscribe();
-        final BlockDetails blockDetails = doRegisterBlockListenerAndTrigger();
+        final Block block = doRegisterBlockListenerAndTrigger();
 
-        assertEquals(BLOCK_NUMBER, blockDetails.getNumber());
+        assertEquals(BLOCK_NUMBER, block.getNumber());
     }
 
     @Test
     public void testBlockTimestampPassedToListenerIsCorrect() {
         underTest.subscribe();
-        final BlockDetails blockDetails = doRegisterBlockListenerAndTrigger();
+        final Block block = doRegisterBlockListenerAndTrigger();
 
-        assertEquals(BLOCK_TIMESTAMP, blockDetails.getTimestamp());
+        assertEquals(BLOCK_TIMESTAMP, block.getTimestamp());
     }
 
     @Test
     public void testBlockNodeNamePassedToListenerIsCorrect() {
         underTest.subscribe();
-        final BlockDetails blockDetails = doRegisterBlockListenerAndTrigger();
+        final Block block = doRegisterBlockListenerAndTrigger();
 
-        assertEquals(NODE_NAME, blockDetails.getNodeName());
+        assertEquals(NODE_NAME, block.getNodeName());
     }
 
-    private BlockDetails doRegisterBlockListenerAndTrigger() {
+    private Block doRegisterBlockListenerAndTrigger() {
 
         mockBlockListener = mock(BlockListener.class);
         underTest.addBlockListener(mockBlockListener);
 
         blockPublishProcessor.onNext(mockEthBlock);
 
-        final ArgumentCaptor<BlockDetails> captor = ArgumentCaptor.forClass(BlockDetails.class);
+        final ArgumentCaptor<Block> captor = ArgumentCaptor.forClass(Block.class);
         verify(mockBlockListener).onBlock(captor.capture());
 
         return captor.getValue();

--- a/server/src/test/java/net/consensys/eventeumserver/integrationtest/BroadcasterPubSubIT.java
+++ b/server/src/test/java/net/consensys/eventeumserver/integrationtest/BroadcasterPubSubIT.java
@@ -34,6 +34,11 @@ public class BroadcasterPubSubIT extends MainBroadcasterTests {
     }
 
     @Test
+    public void testBroadcastBlock() throws Exception {
+        doTestBroadcastBlock();
+    }
+
+    @Test
     public void testBroadcastsUnconfirmedTransactionAfterInitialMining() throws Exception {
         doTestBroadcastsUnconfirmedTransactionAfterInitialMining();
     }
@@ -41,5 +46,20 @@ public class BroadcasterPubSubIT extends MainBroadcasterTests {
     @Test
     public void testBroadcastsConfirmedTransactionAfterBlockThresholdReached() throws Exception {
         doTestBroadcastsConfirmedTransactionAfterBlockThresholdReached();
+    }
+
+    @Test
+    public void testBroadcastFailedTransactionFilteredByHash() throws Exception {
+        doTestBroadcastFailedTransactionFilteredByHash();
+    }
+
+    @Test
+    public void testBroadcastFailedTransactionFilteredByTo() throws Exception {
+        doTestBroadcastFailedTransactionFilteredByTo();
+    }
+
+    @Test
+    public void testBroadcastFailedTransactionFilteredByFrom() throws Exception {
+        doTestBroadcastFailedTransactionFilteredByFrom();
     }
 }


### PR DESCRIPTION
This has the affect of halving the number of 'getBlock' calls to the ethereum node in polling mode.