### PR TITLE
Add revert reason

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,6 +389,7 @@ Eventeum can either be configured by:
 | ETHEREUM_NODE_URL | http://localhost:8545 | The default ethereum node url. |
 | ETHEREUM_NODE_BLOCKSTRATEGY | POLL | The strategy for obtaining block events for the ethereum node (POLL or PUBSUB).
 | ETHEREUM_NODE _HEALTHCHECK_POLLINTERVAL | 2000 | The interval time in ms, in which a request is made to the ethereum node, to ensure that the node is running and functional. |
+| ETHEREUM_NODE_ADD_TRANSACTION_REVERT_REASON | false | In case of a failing transaction it indicates if Eventeum should get the revert reason. Currently not working for Ganache and Parity.
 | POLLING_INTERVAL | 10000 | The polling interval used by Web3j to get events from the blockchain. |
 | EVENTSTORE_TYPE | DB | The type of eventstore used in Eventeum. (See the Advanced section for more details) |
 | BROADCASTER_TYPE | KAFKA | The broadcast mechanism to use.  (KAFKA or HTTP or RABBIT) |

--- a/core/src/main/java/net/consensys/eventeum/chain/block/tx/DefaultTransactionMonitoringBlockListener.java
+++ b/core/src/main/java/net/consensys/eventeum/chain/block/tx/DefaultTransactionMonitoringBlockListener.java
@@ -1,6 +1,5 @@
 package net.consensys.eventeum.chain.block.tx;
 
-import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import net.consensys.eventeum.chain.block.tx.criteria.TransactionMatchingCriteria;
 import net.consensys.eventeum.chain.config.EventConfirmationConfig;

--- a/core/src/main/java/net/consensys/eventeum/chain/block/tx/DefaultTransactionMonitoringBlockListener.java
+++ b/core/src/main/java/net/consensys/eventeum/chain/block/tx/DefaultTransactionMonitoringBlockListener.java
@@ -20,6 +20,7 @@ import org.springframework.retry.backoff.FixedBackOffPolicy;
 import org.springframework.retry.policy.SimpleRetryPolicy;
 import org.springframework.retry.support.RetryTemplate;
 import org.springframework.stereotype.Component;
+import org.web3j.utils.Numeric;
 
 import java.math.BigInteger;
 import java.util.*;
@@ -166,6 +167,17 @@ public class DefaultTransactionMonitoringBlockListener implements TransactionMon
         } else {
             if (!isSuccess) {
                 txDetails.setStatus(TransactionStatus.FAILED);
+
+                String reason = getBlockchainService(txDetails.getNodeName()).getRevertReason(
+                        txDetails.getFrom(),
+                        txDetails.getTo(),
+                        Numeric.toBigInt(txDetails.getBlockNumber()),
+                        txDetails.getInput()
+                );
+
+                if (reason != null) {
+                    txDetails.setRevertReason(reason);
+                }
             }
 
             broadcastTransaction(txDetails, matchingCriteria);

--- a/core/src/main/java/net/consensys/eventeum/chain/block/tx/DefaultTransactionMonitoringBlockListener.java
+++ b/core/src/main/java/net/consensys/eventeum/chain/block/tx/DefaultTransactionMonitoringBlockListener.java
@@ -185,12 +185,7 @@ public class DefaultTransactionMonitoringBlockListener implements TransactionMon
             if (!isSuccess) {
                 txDetails.setStatus(TransactionStatus.FAILED);
 
-                String reason = getBlockchainService(txDetails.getNodeName()).getRevertReason(
-                        txDetails.getFrom(),
-                        txDetails.getTo(),
-                        Numeric.toBigInt(txDetails.getBlockNumber()),
-                        txDetails.getInput()
-                );
+                String reason = getRevertReason(txDetails);
 
                 if (reason != null) {
                     txDetails.setRevertReason(reason);
@@ -241,5 +236,20 @@ public class DefaultTransactionMonitoringBlockListener implements TransactionMon
 
             removeMatchingCriteria(matchingCriteria);
         }
+    }
+
+    private String getRevertReason(TransactionDetails txDetails) {
+        Node node = nodes.get(txDetails.getNodeName());
+
+        if (!node.getAddTransactionRevertReason()) {
+            return null;
+        }
+
+        return getBlockchainService(txDetails.getNodeName()).getRevertReason(
+                txDetails.getFrom(),
+                txDetails.getTo(),
+                Numeric.toBigInt(txDetails.getBlockNumber()),
+                txDetails.getInput()
+        );
     }
 }

--- a/core/src/main/java/net/consensys/eventeum/chain/config/BlockchainServiceRegistrar.java
+++ b/core/src/main/java/net/consensys/eventeum/chain/config/BlockchainServiceRegistrar.java
@@ -1,7 +1,6 @@
 package net.consensys.eventeum.chain.config;
 
 import lombok.Setter;
-import net.consensys.eventeum.chain.settings.Node;
 import net.consensys.eventeum.chain.settings.NodeSettings;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.context.EnvironmentAware;
@@ -18,7 +17,7 @@ public class BlockchainServiceRegistrar implements ImportBeanDefinitionRegistrar
     public void registerBeanDefinitions(AnnotationMetadata importingClassMetadata, BeanDefinitionRegistry registry) {
         final NodeSettings nodeSettings = getNodeSettings();
 
-        nodeSettings.getNodes().forEach(node ->
+        nodeSettings.getNodes().forEach((name, node) ->
                 getNodeBeanRegistratioStrategy(nodeSettings).register(node, registry));
     }
 

--- a/core/src/main/java/net/consensys/eventeum/chain/service/BlockchainService.java
+++ b/core/src/main/java/net/consensys/eventeum/chain/service/BlockchainService.java
@@ -91,4 +91,6 @@ public interface BlockchainService {
      * @return true if the service is correctly connected to the ethereum node.
      */
     boolean isConnected();
+
+    String getRevertReason(String from, String to, BigInteger blockNumber, String input);
 }

--- a/core/src/main/java/net/consensys/eventeum/chain/service/Web3jService.java
+++ b/core/src/main/java/net/consensys/eventeum/chain/service/Web3jService.java
@@ -19,11 +19,14 @@ import net.consensys.eventeum.chain.block.BlockListener;
 import net.consensys.eventeum.chain.contract.ContractEventListener;
 import net.consensys.eventeum.model.FilterSubscription;
 import org.web3j.protocol.Web3j;
+import org.web3j.protocol.core.DefaultBlockParameter;
 import org.web3j.protocol.core.DefaultBlockParameterName;
 import org.web3j.protocol.core.DefaultBlockParameterNumber;
 import org.web3j.protocol.core.filters.FilterException;
 import org.web3j.protocol.core.methods.request.EthFilter;
+import org.web3j.protocol.core.methods.request.Transaction;
 import org.web3j.protocol.core.methods.response.*;
+import org.web3j.utils.Numeric;
 
 import javax.annotation.PreDestroy;
 import java.io.IOException;
@@ -202,6 +205,18 @@ public class Web3jService implements BlockchainService {
     @Override
     public boolean isConnected() {
         return blockSubscriptionStrategy != null && blockSubscriptionStrategy.isSubscribed();
+    }
+
+    @Override
+    public String getRevertReason(String from, String to, BigInteger blockNumber, String input) {
+        try {
+            return web3j.ethCall(
+                    Transaction.createEthCallTransaction(from, to, input),
+                    DefaultBlockParameter.valueOf(blockNumber)
+            ).send().getRevertReason();
+        } catch (IOException e) {
+            throw new BlockchainException("Error getting the revert reason", e);
+        }
     }
 
     @PreDestroy

--- a/core/src/main/java/net/consensys/eventeum/chain/settings/Node.java
+++ b/core/src/main/java/net/consensys/eventeum/chain/settings/Node.java
@@ -14,4 +14,5 @@ public class Node {
     private String username;
     private String password;
     private String blockStrategy;
+    private Boolean addTransactionRevertReason;
 }

--- a/core/src/main/java/net/consensys/eventeum/chain/settings/NodeSettings.java
+++ b/core/src/main/java/net/consensys/eventeum/chain/settings/NodeSettings.java
@@ -28,6 +28,8 @@ public class NodeSettings {
 
     private static final String BLOCK_STRATEGY_ATTRIBUTE = "blockStrategy";
 
+    private static final String TRANSACTION_REVERT_REASON = "addTransactionRevertReason";
+
     private List<Node> nodes;
 
     private String blockStrategy;
@@ -50,7 +52,9 @@ public class NodeSettings {
                     getNodePollingIntervalProperty(environment, index),
                     getNodeUsernameProperty(environment, index),
                     getNodePasswordProperty(environment, index),
-                    getNodeBlockStrategyProperty(environment, index)));
+                    getNodeBlockStrategyProperty(environment, index),
+                    getNodeTransactionRevertReasonProperty(environment, index)
+            ));
 
             index++;
         }
@@ -93,6 +97,10 @@ public class NodeSettings {
 
     private String getNodeBlockStrategyProperty(Environment environment, int index) {
         return getProperty(environment, buildNodeAttribute(BLOCK_STRATEGY_ATTRIBUTE, index));
+    }
+
+    private Boolean getNodeTransactionRevertReasonProperty(Environment environment, int index) {
+        return Boolean.parseBoolean(getProperty(environment, buildNodeAttribute(TRANSACTION_REVERT_REASON, index)));
     }
 
     private String getProperty(Environment environment, String property) {

--- a/core/src/main/java/net/consensys/eventeum/chain/settings/NodeSettings.java
+++ b/core/src/main/java/net/consensys/eventeum/chain/settings/NodeSettings.java
@@ -1,7 +1,6 @@
 package net.consensys.eventeum.chain.settings;
 
 import java.util.HashMap;
-import java.util.Map;
 import lombok.Data;
 import net.consensys.eventeum.chain.service.BlockchainException;
 import org.springframework.core.env.Environment;
@@ -31,7 +30,7 @@ public class NodeSettings {
 
     private static final String TRANSACTION_REVERT_REASON = "addTransactionRevertReason";
 
-    private Map<String, Node> nodes;
+    private HashMap<String, Node> nodes;
 
     private String blockStrategy;
 

--- a/core/src/main/java/net/consensys/eventeum/chain/settings/NodeSettings.java
+++ b/core/src/main/java/net/consensys/eventeum/chain/settings/NodeSettings.java
@@ -1,13 +1,14 @@
 package net.consensys.eventeum.chain.settings;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
 import lombok.Data;
 import net.consensys.eventeum.chain.service.BlockchainException;
 import org.springframework.core.env.Environment;
-import org.web3j.abi.datatypes.Int;
+import org.springframework.stereotype.Component;
 
 @Data
+@Component
 public class NodeSettings {
 
     private static final Long DEFAULT_POLLING_INTERVAL = 10000l;
@@ -30,7 +31,7 @@ public class NodeSettings {
 
     private static final String TRANSACTION_REVERT_REASON = "addTransactionRevertReason";
 
-    private List<Node> nodes;
+    private Map<String, Node> nodes;
 
     private String blockStrategy;
 
@@ -40,22 +41,27 @@ public class NodeSettings {
         blockStrategy = environment.getProperty(ATTRIBUTE_PREFIX + "." + BLOCK_STRATEGY_ATTRIBUTE);
     }
 
-    private void populateNodeSettings(Environment environment) {
-        nodes = new ArrayList<>();
+    public Node getNode(String nodeName) {
+        return nodes.get(nodeName);
+    }
 
+    private void populateNodeSettings(Environment environment) {
+        nodes = new HashMap <String, Node>();
         int index = 0;
 
         while (nodeExistsAtIndex(environment, index)) {
-            nodes.add(new Node(
-                    getNodeNameProperty(environment, index),
+            String nodeName = getNodeNameProperty(environment, index);
+            Node node = new Node(
+                    nodeName,
                     getNodeUrlProperty(environment, index),
                     getNodePollingIntervalProperty(environment, index),
                     getNodeUsernameProperty(environment, index),
                     getNodePasswordProperty(environment, index),
                     getNodeBlockStrategyProperty(environment, index),
                     getNodeTransactionRevertReasonProperty(environment, index)
-            ));
+            );
 
+            nodes.put(nodeName, node);
             index++;
         }
 

--- a/core/src/main/java/net/consensys/eventeum/dto/transaction/TransactionDetails.java
+++ b/core/src/main/java/net/consensys/eventeum/dto/transaction/TransactionDetails.java
@@ -23,6 +23,8 @@ public class TransactionDetails {
     private String value;
     private String nodeName;
     private String contractAddress;
+    private String input;
+    private String revertReason;
 
     private TransactionStatus status;
 }

--- a/core/src/test/java/net/consensys/eventeum/chain/service/Web3jServiceTest.java
+++ b/core/src/test/java/net/consensys/eventeum/chain/service/Web3jServiceTest.java
@@ -13,8 +13,10 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.web3j.protocol.Web3j;
+import org.web3j.protocol.core.DefaultBlockParameter;
 import org.web3j.protocol.core.Request;
 import org.web3j.protocol.core.methods.request.EthFilter;
+import org.web3j.protocol.core.methods.request.Transaction;
 import org.web3j.protocol.core.methods.response.*;
 
 import java.io.IOException;
@@ -38,6 +40,8 @@ public class Web3jServiceTest {
     private static final BigInteger BLOCK_NUMBER = BigInteger.valueOf(123);
 
     private static final String CONTRACT_ADDRESS = "0x7a55a28856d43bba3c6a7e36f2cee9a82923e99b";
+
+    private static final String REVERT_REASON = "error";
 
     private Web3jService underTest;
 
@@ -154,6 +158,18 @@ public class Web3jServiceTest {
         when(mockRequest.send()).thenThrow(new IOException());
         doReturn(mockRequest).when(mockWeb3j).ethBlockNumber();
         underTest.getCurrentBlockNumber();
+    }
+
+    @Test
+    public void testGetRevertReason() throws IOException {
+        final Request<?, EthCall> mockRequest = mock(Request.class);
+        final EthCall ethCall = mock(EthCall.class);
+
+        when(ethCall.getRevertReason()).thenReturn(REVERT_REASON);
+        when(mockRequest.send()).thenReturn(ethCall);
+        doReturn(mockRequest).when(mockWeb3j).ethCall(any(Transaction.class), any(DefaultBlockParameter.class));
+
+        assertEquals(REVERT_REASON, underTest.getRevertReason(FROM_ADDRESS, TO_ADDRESS, BLOCK_NUMBER, "0x1"));
     }
 
     private ContractEventDetails doRegisterEventListenerAndTrigger() {

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -39,7 +39,7 @@ ethereum:
 #      type: NON_INDEXED_PARAMETER
 #      index: 0
 
-#contractTransactionFilters:
+#transactionFilters:
 #- nodeName: ${ETHEREUM_NETWORK:DefaultNetwork}
 #  type: "FROM_ADDRESS"
 #  transactionIdentifierValue: ${CONTRACT_ADDRESS_EM_TOKEN:0x0f8E7A681019Ec13EfE853a6Eca666E05b214Fd5}


### PR DESCRIPTION
The idea of this PR is adding the `revertReason` into the failed transaction payload. 

This affects to the failing transaction. It will ask to the node for the failing transaction.

In the new version of web3j that was integrated into Eventeum it was added the revert reason in the EthCall: https://github.com/web3j/web3j/blob/23beb6f394afabe143f1904d8179180152f8f212/core/src/main/java/org/web3j/protocol/core/methods/response/EthCall.java#L44

The ethCall is a query call that simulates the function call but without performing any change in the chain. It only adds a bit delay in emitting the failing event because it is calling the node to check the revert reason.

We think this is a very big feature to have in Eventeum because it notifies about the error inside the transaction failed event payload.


