### PR TITLE
Fix secured connection to kafka for both consumer and producer. Suppo…

### DIFF
--- a/core/src/main/java/net/consensys/eventeum/config/KafkaConfiguration.java
+++ b/core/src/main/java/net/consensys/eventeum/config/KafkaConfiguration.java
@@ -38,6 +38,12 @@ public class KafkaConfiguration {
     public KafkaAdmin eventeumAdmin() {
         Map<String, Object> configs = new HashMap<>();
         configs.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, settings.getBootstrapAddresses());
+        configs.put(AdminClientConfig.REQUEST_TIMEOUT_MS_CONFIG, settings.getRequestTimeoutMsConfig());
+        configs.put(AdminClientConfig.RETRY_BACKOFF_MS_CONFIG, settings.getRetryBackoffMsConfig());
+        configs.put("retries", settings.getRetries());
+        if (!"PLAINTEXT".equals(settings.getSecurityProtocol())) {
+            configurePlaintextSecurityProtocol(configs);
+        }
         return new KafkaAdmin(configs);
     }
 
@@ -51,7 +57,7 @@ public class KafkaConfiguration {
         configProps.put(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, settings.getRequestTimeoutMsConfig());
         configProps.put(ProducerConfig.RETRY_BACKOFF_MS_CONFIG, settings.getRetryBackoffMsConfig());
         configProps.put("retries", settings.getRetries());
-        if ("PLAINTEXT".equals(settings.getSecurityProtocol())) {
+        if (!"PLAINTEXT".equals(settings.getSecurityProtocol())) {
             configurePlaintextSecurityProtocol(configProps);
         }
         return new DefaultKafkaProducerFactory<>(configProps);
@@ -63,9 +69,9 @@ public class KafkaConfiguration {
         props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, settings.getBootstrapAddresses());
         props.put(ConsumerConfig.GROUP_ID_CONFIG, settings.getGroupId());
         props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-        props.put(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, settings.getRequestTimeoutMsConfig());
-        props.put(ProducerConfig.RETRY_BACKOFF_MS_CONFIG, settings.getRetryBackoffMsConfig());
-        if ("PLAINTEXT".equals(settings.getSecurityProtocol())) {
+        props.put(ConsumerConfig.REQUEST_TIMEOUT_MS_CONFIG, settings.getRequestTimeoutMsConfig());
+        props.put(ConsumerConfig.RETRY_BACKOFF_MS_CONFIG, settings.getRetryBackoffMsConfig());
+        if (!"PLAINTEXT".equals(settings.getSecurityProtocol())) {
             configurePlaintextSecurityProtocol(props);
         }
         return new DefaultKafkaConsumerFactory<>(props, null, new JsonDeserializer<>(EventeumMessage.class));
@@ -77,7 +83,11 @@ public class KafkaConfiguration {
         props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, settings.getBootstrapAddresses());
         props.put(ConsumerConfig.GROUP_ID_CONFIG, settings.getGroupId());
         props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-
+        props.put(ConsumerConfig.REQUEST_TIMEOUT_MS_CONFIG, settings.getRequestTimeoutMsConfig());
+        props.put(ConsumerConfig.RETRY_BACKOFF_MS_CONFIG, settings.getRetryBackoffMsConfig());
+        if (!"PLAINTEXT".equals(settings.getSecurityProtocol())) {
+            configurePlaintextSecurityProtocol(props);
+        }
         return new DefaultKafkaConsumerFactory<>(props, null, new JsonDeserializer<>(Object.class));
     }
 


### PR DESCRIPTION
Use a kafka secure connection only if security protocol is different than `PLAINTEXT` . Add support for secure connection to kafka `AdminClient` 