### PR TITLE
Allow block notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,6 +399,7 @@ Eventeum can either be configured by:
 | BROADCASTER_HTTP CONTRACTEVENTSURL | | The http url for posting contract events (for HTTP broadcasting) |
 | BROADCASTER_HTTP BLOCKEVENTSURL | | The http url for posting block events (for HTTP broadcasting) |
 | BROADCASTER_BYTESTOASCII | false | If any bytes values within events should be converted to ascii (default is hex) |
+| BROADCASTER_ALLOW_BLOCK_NOTIFICATION | true | Boolean that indicates if want to receive block notifications or not. Set false to not receive that event. |
 | ZOOKEEPER_ADDRESS | localhost:2181 | The zookeeper address |
 | KAFKA_ADDRESSES | localhost:9092 | Comma seperated list of kafka addresses |
 | KAFKA_TOPIC_CONTRACT_EVENTS | contract-events | The topic name for broadcast contract event messages |

--- a/README.md
+++ b/README.md
@@ -399,7 +399,7 @@ Eventeum can either be configured by:
 | BROADCASTER_HTTP CONTRACTEVENTSURL | | The http url for posting contract events (for HTTP broadcasting) |
 | BROADCASTER_HTTP BLOCKEVENTSURL | | The http url for posting block events (for HTTP broadcasting) |
 | BROADCASTER_BYTESTOASCII | false | If any bytes values within events should be converted to ascii (default is hex) |
-| BROADCASTER_ALLOW_BLOCK_NOTIFICATION | true | Boolean that indicates if want to receive block notifications or not. Set false to not receive that event. |
+| BROADCASTER_ENABLE_BLOCK_NOTIFICATION | true | Boolean that indicates if want to receive block notifications or not. Set false to not receive that event. |
 | ZOOKEEPER_ADDRESS | localhost:2181 | The zookeeper address |
 | KAFKA_ADDRESSES | localhost:9092 | Comma seperated list of kafka addresses |
 | KAFKA_TOPIC_CONTRACT_EVENTS | contract-events | The topic name for broadcast contract event messages |

--- a/core/src/main/java/net/consensys/eventeum/config/BlockchainEventBroadcasterConfiguration.java
+++ b/core/src/main/java/net/consensys/eventeum/config/BlockchainEventBroadcasterConfiguration.java
@@ -25,7 +25,7 @@ import net.consensys.eventeum.integration.broadcast.blockchain.BlockchainEventBr
 import net.consensys.eventeum.integration.broadcast.blockchain.HttpBlockchainEventBroadcaster;
 import net.consensys.eventeum.integration.broadcast.blockchain.HttpBroadcasterSettings;
 import net.consensys.eventeum.integration.broadcast.blockchain.KafkaBlockchainEventBroadcaster;
-import net.consensys.eventeum.integration.broadcast.blockchain.OnlyOnceBlockchainEventBroadcasterWrapper;
+import net.consensys.eventeum.integration.broadcast.blockchain.EventBroadcasterWrapper;
 import net.consensys.eventeum.integration.broadcast.blockchain.PulsarBlockChainEventBroadcaster;
 import net.consensys.eventeum.integration.broadcast.blockchain.RabbitBlockChainEventBroadcaster;
 
@@ -107,6 +107,6 @@ public class BlockchainEventBroadcasterConfiguration {
     }
 
     private BlockchainEventBroadcaster onlyOnceWrap(BlockchainEventBroadcaster toWrap) {
-        return new OnlyOnceBlockchainEventBroadcasterWrapper(onlyOnceCacheExpirationTime, toWrap);
+        return new EventBroadcasterWrapper(onlyOnceCacheExpirationTime, toWrap, allowBlockNotification);
     }
 }

--- a/core/src/main/java/net/consensys/eventeum/config/BlockchainEventBroadcasterConfiguration.java
+++ b/core/src/main/java/net/consensys/eventeum/config/BlockchainEventBroadcasterConfiguration.java
@@ -41,13 +41,13 @@ public class BlockchainEventBroadcasterConfiguration {
 
     private static final String EXPIRATION_PROPERTY = "${broadcaster.cache.expirationMillis}";
     private static final String BROADCASTER_PROPERTY = "broadcaster.type";
-    private static final String BLOCK_NOTIFICATION = "${broadcaster.allowBlockNotification:true}";
+    private static final String ALLOW_BLOCK_NOTIFICATION = "${broadcaster.allowBlockNotification:true}";
 
     private Long onlyOnceCacheExpirationTime;
     private boolean allowBlockNotification;
 
     @Autowired
-    public BlockchainEventBroadcasterConfiguration(@Value(EXPIRATION_PROPERTY) Long onlyOnceCacheExpirationTime, @Value(BLOCK_NOTIFICATION) boolean allowBlockNotification) {
+    public BlockchainEventBroadcasterConfiguration(@Value(EXPIRATION_PROPERTY) Long onlyOnceCacheExpirationTime, @Value(ALLOW_BLOCK_NOTIFICATION) boolean allowBlockNotification) {
         this.onlyOnceCacheExpirationTime = onlyOnceCacheExpirationTime;
         this.allowBlockNotification = allowBlockNotification;
     }

--- a/core/src/main/java/net/consensys/eventeum/config/BlockchainEventBroadcasterConfiguration.java
+++ b/core/src/main/java/net/consensys/eventeum/config/BlockchainEventBroadcasterConfiguration.java
@@ -41,15 +41,15 @@ public class BlockchainEventBroadcasterConfiguration {
 
     private static final String EXPIRATION_PROPERTY = "${broadcaster.cache.expirationMillis}";
     private static final String BROADCASTER_PROPERTY = "broadcaster.type";
-    private static final String ALLOW_BLOCK_NOTIFICATION = "${broadcaster.allowBlockNotification:true}";
+    private static final String ENABLE_BLOCK_NOTIFICATIONS = "${broadcaster.enableBlockNotifications:true}";
 
     private Long onlyOnceCacheExpirationTime;
-    private boolean allowBlockNotification;
+    private boolean enableBlockNotifications;
 
     @Autowired
-    public BlockchainEventBroadcasterConfiguration(@Value(EXPIRATION_PROPERTY) Long onlyOnceCacheExpirationTime, @Value(ALLOW_BLOCK_NOTIFICATION) boolean allowBlockNotification) {
+    public BlockchainEventBroadcasterConfiguration(@Value(EXPIRATION_PROPERTY) Long onlyOnceCacheExpirationTime, @Value(ENABLE_BLOCK_NOTIFICATIONS) boolean enableBlockNotifications) {
         this.onlyOnceCacheExpirationTime = onlyOnceCacheExpirationTime;
-        this.allowBlockNotification = allowBlockNotification;
+        this.enableBlockNotifications = enableBlockNotifications;
     }
 
     @Bean
@@ -110,6 +110,6 @@ public class BlockchainEventBroadcasterConfiguration {
     }
 
     private BlockchainEventBroadcaster onlyOnceWrap(BlockchainEventBroadcaster toWrap) {
-        return new EventBroadcasterWrapper(onlyOnceCacheExpirationTime, toWrap, allowBlockNotification);
+        return new EventBroadcasterWrapper(onlyOnceCacheExpirationTime, toWrap, enableBlockNotifications);
     }
 }

--- a/core/src/main/java/net/consensys/eventeum/config/BlockchainEventBroadcasterConfiguration.java
+++ b/core/src/main/java/net/consensys/eventeum/config/BlockchainEventBroadcasterConfiguration.java
@@ -41,12 +41,15 @@ public class BlockchainEventBroadcasterConfiguration {
 
     private static final String EXPIRATION_PROPERTY = "${broadcaster.cache.expirationMillis}";
     private static final String BROADCASTER_PROPERTY = "broadcaster.type";
+    private static final String BLOCK_NOTIFICATION = "${broadcaster.allowBlockNotification:true}";
 
     private Long onlyOnceCacheExpirationTime;
+    private boolean allowBlockNotification;
 
     @Autowired
-    public BlockchainEventBroadcasterConfiguration(@Value(EXPIRATION_PROPERTY) Long onlyOnceCacheExpirationTime) {
+    public BlockchainEventBroadcasterConfiguration(@Value(EXPIRATION_PROPERTY) Long onlyOnceCacheExpirationTime, @Value(BLOCK_NOTIFICATION) boolean allowBlockNotification) {
         this.onlyOnceCacheExpirationTime = onlyOnceCacheExpirationTime;
+        this.allowBlockNotification = allowBlockNotification;
     }
 
     @Bean

--- a/core/src/main/java/net/consensys/eventeum/integration/broadcast/blockchain/EventBroadcasterWrapper.java
+++ b/core/src/main/java/net/consensys/eventeum/integration/broadcast/blockchain/EventBroadcasterWrapper.java
@@ -32,21 +32,21 @@ public class EventBroadcasterWrapper implements BlockchainEventBroadcaster {
 
     private BlockchainEventBroadcaster wrapped;
 
-    private boolean allowBlockNotification;
+    private boolean enableBlockNotifications;
 
     public EventBroadcasterWrapper(Long expirationTimeMillis,
                                    BlockchainEventBroadcaster toWrap,
-                                   boolean allowBlockNotification) {
+                                   boolean enableBlockNotifications) {
         this.expirationTimeMillis = expirationTimeMillis;
         this.contractEventCache = createCache(ContractEventDetails.class);
         this.transactionCache = createCache(TransactionDetails.class);
         this.wrapped = toWrap;
-        this.allowBlockNotification = allowBlockNotification;
+        this.enableBlockNotifications = enableBlockNotifications;
     }
 
     @Override
     public void broadcastNewBlock(BlockDetails block) {
-        if (!this.allowBlockNotification) {
+        if (!this.enableBlockNotifications) {
             return;
         }
 

--- a/core/src/main/java/net/consensys/eventeum/integration/broadcast/blockchain/EventBroadcasterWrapper.java
+++ b/core/src/main/java/net/consensys/eventeum/integration/broadcast/blockchain/EventBroadcasterWrapper.java
@@ -20,7 +20,7 @@ import java.util.concurrent.TimeUnit;
  *
  * @author Craig Williams <craig.williams@consensys.net>
  */
-public class OnlyOnceBlockchainEventBroadcasterWrapper implements BlockchainEventBroadcaster {
+public class EventBroadcasterWrapper implements BlockchainEventBroadcaster {
 
     private Cache<Integer, ContractEventDetails> contractEventCache;
 
@@ -32,16 +32,24 @@ public class OnlyOnceBlockchainEventBroadcasterWrapper implements BlockchainEven
 
     private BlockchainEventBroadcaster wrapped;
 
-    public OnlyOnceBlockchainEventBroadcasterWrapper(Long expirationTimeMillis,
-                                              BlockchainEventBroadcaster toWrap) {
+    private boolean allowBlockNotification;
+
+    public EventBroadcasterWrapper(Long expirationTimeMillis,
+                                   BlockchainEventBroadcaster toWrap,
+                                   boolean allowBlockNotification) {
         this.expirationTimeMillis = expirationTimeMillis;
         this.contractEventCache = createCache(ContractEventDetails.class);
         this.transactionCache = createCache(TransactionDetails.class);
         this.wrapped = toWrap;
+        this.allowBlockNotification = allowBlockNotification;
     }
 
     @Override
     public void broadcastNewBlock(BlockDetails block) {
+        if (!this.allowBlockNotification) {
+            return;
+        }
+
         wrapped.broadcastNewBlock(block);
     }
 

--- a/core/src/test/java/net/consensys/eventeum/integration/broadcast/EventBroadcasterWrapperTest.java
+++ b/core/src/test/java/net/consensys/eventeum/integration/broadcast/EventBroadcasterWrapperTest.java
@@ -32,7 +32,7 @@ public class EventBroadcasterWrapperTest {
     }
 
     @Test
-    public void testAllowBlockNotification() {
+    public void testEnableBlockNotifications() {
         EventBroadcasterWrapper underTest = new EventBroadcasterWrapper(EXPIRATION_MILLISECONDS, blockchainEventBroadcaster, true);
         final BlockDetails block = new BlockDetails();
 

--- a/core/src/test/java/net/consensys/eventeum/integration/broadcast/EventBroadcasterWrapperTest.java
+++ b/core/src/test/java/net/consensys/eventeum/integration/broadcast/EventBroadcasterWrapperTest.java
@@ -1,0 +1,43 @@
+package net.consensys.eventeum.integration.broadcast;
+
+import net.consensys.eventeum.dto.block.BlockDetails;
+import net.consensys.eventeum.integration.broadcast.blockchain.BlockchainEventBroadcaster;
+import net.consensys.eventeum.integration.broadcast.blockchain.EventBroadcasterWrapper;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+public class EventBroadcasterWrapperTest {
+
+    private static final Long EXPIRATION_MILLISECONDS = 6000000L;
+
+    private BlockchainEventBroadcaster blockchainEventBroadcaster;
+
+    @Before
+    public void init() {
+        blockchainEventBroadcaster = Mockito.mock(BlockchainEventBroadcaster.class);
+    }
+
+    @Test
+    public void testDisableBlockNotification() {
+        EventBroadcasterWrapper underTest = new EventBroadcasterWrapper(EXPIRATION_MILLISECONDS, blockchainEventBroadcaster, false);
+        final BlockDetails block = new BlockDetails();
+
+        underTest.broadcastNewBlock(block);PulsarBlockChainEventBroadcaster
+
+        verify(blockchainEventBroadcaster, never()).broadcastNewBlock(block);
+    }
+
+    @Test
+    public void testAllowBlockNotification() {
+        EventBroadcasterWrapper underTest = new EventBroadcasterWrapper(EXPIRATION_MILLISECONDS, blockchainEventBroadcaster, true);
+        final BlockDetails block = new BlockDetails();
+
+        underTest.broadcastNewBlock(block);
+
+        verify(blockchainEventBroadcaster).broadcastNewBlock(block);
+    }
+}

--- a/core/src/test/java/net/consensys/eventeum/integration/broadcast/EventBroadcasterWrapperTest.java
+++ b/core/src/test/java/net/consensys/eventeum/integration/broadcast/EventBroadcasterWrapperTest.java
@@ -26,7 +26,7 @@ public class EventBroadcasterWrapperTest {
         EventBroadcasterWrapper underTest = new EventBroadcasterWrapper(EXPIRATION_MILLISECONDS, blockchainEventBroadcaster, false);
         final BlockDetails block = new BlockDetails();
 
-        underTest.broadcastNewBlock(block);PulsarBlockChainEventBroadcaster
+        underTest.broadcastNewBlock(block);
 
         verify(blockchainEventBroadcaster, never()).broadcastNewBlock(block);
     }

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -66,7 +66,7 @@ broadcaster:
       numBlocksToWait: 12
       numBlocksToWaitForMissingTx: 100
   multiInstance: false
-  allowBlockNotification: true
+  enableBlockNotifications: true
 
 # For Kafka
 zookeeper:

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -66,6 +66,7 @@ broadcaster:
       numBlocksToWait: 12
       numBlocksToWaitForMissingTx: 100
   multiInstance: false
+  allowBlockNotification: true
 
 # For Kafka
 zookeeper:


### PR DESCRIPTION
- It sets a variable `allowBlockNotification` to disable the block notifications. By default is set to true to keep the compatibility.

- I used the wrapper class named: `OnlyOnceBlockchainEventBroadcasterWrapper`. The reason is all the broadcaster are using that wrapper. So in stead of implementing "N" times the `if`, I think is better to use that class. To Avoid misunderstandings I renamed the class to: `EventBroadcasterWrapper`

