### PR TITLE
Closes #91: Add a GET endpoint to list filter subscriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,56 @@ eventFilters:
     -   **Code:** 200
         **Content:** `N/A`
 
+## Listing Registered Events
+
+### REST
+
+-   **URL:** `/api/rest/v1/event-filter`    
+-   **Method:** `GET`
+-   **Headers:**  
+
+| Key | Value |
+| -------- | -------- |
+| accept | application/json |
+
+-   **URL Params:** `N/A`
+
+-   **Response:** List of contract event filters:
+```json
+[{
+	"id": "event-identifier-1",
+	"contractAddress": "0x1fbBeeE6eC2B7B095fE3c5A572551b1e260Af4d2",
+	"eventSpecification": {
+		"eventName": "TestEvent",
+		"indexedParameterDefinitions": [
+		  {"position": 0, "type": "UINT256"},
+		  {"position": 1, "type": "ADDRESS"}],
+		"nonIndexedParameterDefinitions": [
+		  {"position": 2, "type": "BYTES32"},
+		  {"position": 3, "type": "STRING"}] },
+	"correlationIdStrategy": {
+		"type": "NON_INDEXED_PARAMETER",
+		"parameterIndex": 0 }
+},
+....
+{
+	"id": "event-identifier-N",
+	"contractAddress": "0x1fbBeeE6eC2B7B095fE3c5A572551b1e260Af4d2",
+	"eventSpecification": {
+		"eventName": "TestEvent",
+		"indexedParameterDefinitions": [
+		  {"position": 0, "type": "UINT256"},
+		  {"position": 1, "type": "ADDRESS"}],
+		"nonIndexedParameterDefinitions": [
+		  {"position": 2, "type": "BYTES32"},
+		  {"position": 3, "type": "STRING"}] },
+	"correlationIdStrategy": {
+		"type": "NON_INDEXED_PARAMETER",
+		"parameterIndex": 0 }
+}
+]
+```
+
 ## Registering a Transaction Monitor
 
 From version 0.6.2, eventeum supports monitoring and broadcasting transactions. The matching criteria can be:

--- a/core/src/main/java/net/consensys/eventeum/endpoint/ContractEventFilterEndpoint.java
+++ b/core/src/main/java/net/consensys/eventeum/endpoint/ContractEventFilterEndpoint.java
@@ -9,6 +9,8 @@ import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletResponse;
 
+import java.util.List;
+
 /**
  * A REST endpoint for adding a removing event filters.
  *
@@ -35,6 +37,19 @@ public class ContractEventFilterEndpoint {
         response.setStatus(HttpServletResponse.SC_ACCEPTED);
 
         return new AddEventFilterResponse(registeredFilter.getId());
+    }
+
+    /**
+     * Returns the list of registered {@link ContractEventFilter}
+     *
+     * @param response the http response
+     */
+    @RequestMapping(method = RequestMethod.GET)
+    public List<ContractEventFilter> listEventFilters(HttpServletResponse response) {
+	List<ContractEventFilter> registeredFilters = filterService.listContractEventFilters();
+	response.setStatus(HttpServletResponse.SC_OK);
+
+        return registeredFilters;
     }
 
     /**

--- a/core/src/main/java/net/consensys/eventeum/service/DefaultSubscriptionService.java
+++ b/core/src/main/java/net/consensys/eventeum/service/DefaultSubscriptionService.java
@@ -105,6 +105,14 @@ public class DefaultSubscriptionService implements SubscriptionService {
      * {@inheritDoc}
      */
     @Override
+    public List<ContractEventFilter> listContractEventFilters() {
+      return getFilterSubscriptions().stream().map((FilterSubscription f) -> f.getFilter()).collect(Collectors.toList());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public void unregisterContractEventFilter(String filterId) throws NotFoundException {
         unregisterContractEventFilter(filterId, true);
     }
@@ -241,6 +249,10 @@ public class DefaultSubscriptionService implements SubscriptionService {
 
     private FilterSubscription getFilterSubscription(String filterId) {
         return filterSubscriptions.get(filterId);
+    }
+
+    private List<FilterSubscription> getFilterSubscriptions() {
+        return new ArrayList(filterSubscriptions.values());
     }
 
     private void removeFilterSubscription(String filterId) {

--- a/core/src/main/java/net/consensys/eventeum/service/SubscriptionService.java
+++ b/core/src/main/java/net/consensys/eventeum/service/SubscriptionService.java
@@ -3,6 +3,8 @@ package net.consensys.eventeum.service;
 import net.consensys.eventeum.dto.event.filter.ContractEventFilter;
 import net.consensys.eventeum.service.exception.NotFoundException;
 
+import java.util.List;
+
 /**
  * A service for manageing contract event subscriptions within the Eventeum instance.
  *
@@ -37,6 +39,13 @@ public interface SubscriptionService {
      * @return The registered contract event filter
      */
     ContractEventFilter registerContractEventFilter(ContractEventFilter filter, boolean broadcast);
+
+    /**
+     * List all registered contract event filters.
+     *
+     * @return The list of registered contract event filters
+     */
+    List<ContractEventFilter> listContractEventFilters();
 
     /**
      * Unregisters a previously added contract event filter.

--- a/core/src/test/java/net/consensys/eventeum/service/DefaultSubscriptionServiceTest.java
+++ b/core/src/test/java/net/consensys/eventeum/service/DefaultSubscriptionServiceTest.java
@@ -141,7 +141,7 @@ public class DefaultSubscriptionServiceTest {
     public void testListContractEventFilterAlreadyRegistered() {
         final ContractEventFilter filter1 = createEventFilter(null);
         when(mockBlockchainService.registerEventListener(any(ContractEventFilter.class), any(ContractEventListener.class)))
-	   .thenReturn(new FilterSubscription(filter1, mock(Subscription.class)));
+	   .thenReturn(new FilterSubscription(filter1, mock(Disposable.class)));
 
         underTest.registerContractEventFilter(filter1, true);
         underTest.registerContractEventFilter(filter1, true);

--- a/core/src/test/java/net/consensys/eventeum/service/DefaultSubscriptionServiceTest.java
+++ b/core/src/test/java/net/consensys/eventeum/service/DefaultSubscriptionServiceTest.java
@@ -101,6 +101,7 @@ public class DefaultSubscriptionServiceTest {
         underTest.registerContractEventFilter(filter);
 
         verifyContractEventFilterRegistration(filter,true, true);
+        assertEquals(1, underTest.listContractEventFilters().size());
     }
 
     @Test
@@ -110,6 +111,7 @@ public class DefaultSubscriptionServiceTest {
         underTest.registerContractEventFilter(filter, false);
 
         verifyContractEventFilterRegistration(filter,true, false);
+        assertEquals(1, underTest.listContractEventFilters().size());
     }
 
     @Test
@@ -119,6 +121,7 @@ public class DefaultSubscriptionServiceTest {
         underTest.registerContractEventFilter(filter, true);
 
         verifyContractEventFilterRegistration(filter,true, true);
+        assertEquals(1, underTest.listContractEventFilters().size());
     }
 
     @Test
@@ -131,6 +134,19 @@ public class DefaultSubscriptionServiceTest {
         underTest.registerContractEventFilter(filter, true);
 
         assertTrue(!filter.getId().isEmpty());
+        assertEquals(1, underTest.listContractEventFilters().size());
+    }
+
+    @Test
+    public void testListContractEventFilterAlreadyRegistered() {
+        final ContractEventFilter filter1 = createEventFilter(null);
+        when(mockBlockchainService.registerEventListener(any(ContractEventFilter.class), any(ContractEventListener.class)))
+	   .thenReturn(new FilterSubscription(filter1, mock(Subscription.class)));
+
+        underTest.registerContractEventFilter(filter1, true);
+        underTest.registerContractEventFilter(filter1, true);
+
+        assertEquals(1, underTest.listContractEventFilters().size());
     }
 
     @Test
@@ -177,6 +193,7 @@ public class DefaultSubscriptionServiceTest {
         verify(sub1, times(1)).dispose();
         verify(mockRepo, times(1)).deleteById(FILTER_ID);
         verify(mockFilterBroadcaster, times(1)).broadcastEventFilterRemoved(filter);
+        assertEquals(0, underTest.listContractEventFilters().size());
 
         boolean exceptionThrown = false;
         //This will test that the filter has been deleted from memory

--- a/server/src/test/java/net/consensys/eventeumserver/integrationtest/BaseIntegrationTest.java
+++ b/server/src/test/java/net/consensys/eventeumserver/integrationtest/BaseIntegrationTest.java
@@ -27,6 +27,8 @@ import org.junit.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.RestTemplate;
 import org.testcontainers.containers.BindMode;
@@ -214,6 +216,18 @@ public class BaseIntegrationTest {
 
         registeredFilters.put(filter.getId(), filter);
         return filter;
+    }
+
+    protected List<ContractEventFilter> listEventFilters() {
+	final ResponseEntity<List<ContractEventFilter>> response = restTemplate.exchange(
+		  restUrl + "/api/rest/v1/event-filter",
+		  HttpMethod.GET,
+		  null,
+		  new ParameterizedTypeReference<List<ContractEventFilter>>(){});
+
+	List<ContractEventFilter> contractEventFilters = response.getBody();
+
+	return contractEventFilters;
     }
 
     protected String monitorTransaction(TransactionMonitoringSpec monitorSpec) {

--- a/server/src/test/java/net/consensys/eventeumserver/integrationtest/RegistrationIT.java
+++ b/server/src/test/java/net/consensys/eventeumserver/integrationtest/RegistrationIT.java
@@ -17,6 +17,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.web.client.HttpClientErrorException;
 import org.web3j.crypto.Hash;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -63,6 +64,17 @@ public class RegistrationIT extends BaseKafkaIntegrationTest {
 
         //This errors if id is not a valid UUID
         UUID.fromString(registeredFilter.getId());
+    }
+
+    @Test
+    public void testListEventFilters() {
+        final ContractEventFilter filter = createDummyEventFilter(FAKE_CONTRACT_ADDRESS);
+
+        registerEventFilter(filter);
+
+	List<ContractEventFilter> contractEventFilters = listEventFilters();
+
+	assertEquals(1, contractEventFilters.size());
     }
 
     @Test


### PR DESCRIPTION
Closes #91 . First approach to have an endpoint to list the existing filter subscriptions. 

Output: 
```
➜  eventeum git:(master) ✗ curl -XGET -H "Content-Type: application/json" localhost:8060/api/rest/v1/event-filter | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   670    0   670    0     0  44666      0 --:--:-- --:--:-- --:--:-- 44666
[
  {
    "id": "my-custom-event",
    "contractAddress": "0xd6dE21390c5D2045A4f8477133bb9a23ea9c3F88",
    "node": "default",
    "eventSpecification": {
      "eventName": "Mint",
      "indexedParameterDefinitions": [
        {
          "position": 0,
          "type": "ADDRESS"
        }
      ],
      "nonIndexedParameterDefinitions": [
        {
          "position": 1,
          "type": "STRING"
        },
        {
          "position": 2,
          "type": "UINT256"
        }
      ]
    },
    "startBlock": 0
  },
  {
    "id": "a17fd147-1c36-4759-b2a4-024d2ac9f46f",
    "contractAddress": "0xd6dE21390c5A2045A4b8477133bb9a23ea9c3F66",
    "node": "default",
    "eventSpecification": {
      "eventName": "Mint",
      "indexedParameterDefinitions": [
        {
          "position": 0,
          "type": "ADDRESS"
        }
      ],
      "nonIndexedParameterDefinitions": [
        {
          "position": 1,
          "type": "STRING"
        },
        {
          "position": 2,
          "type": "UINT256"
        }
      ]
    },
    "startBlock": 0
  }
]
```