### PR TITLE
Wait blocks to invalidate event

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,14 +393,15 @@ Eventeum can either be configured by:
 | ETHEREUM_BLOCKSTRATEGY | POLL | The strategy for obtaining block events from an ethereum node (POLL or PUBSUB). It will be overwritten by the specific node configuration. |
 | ETHEREUM_NODE_URL | http://localhost:8545 | The default ethereum node url. |
 | ETHEREUM_NODE_BLOCKSTRATEGY | POLL | The strategy for obtaining block events for the ethereum node (POLL or PUBSUB).
-| ETHEREUM_NODE _HEALTHCHECK_POLLINTERVAL | 2000 | The interval time in ms, in which a request is made to the ethereum node, to ensure that the node is running and functional. |
+| ETHEREUM_NODE_HEALTHCHECK_POLLINTERVAL | 2000 | The interval time in ms, in which a request is made to the ethereum node, to ensure that the node is running and functional. |
 | ETHEREUM_NODE_ADD_TRANSACTION_REVERT_REASON | false | In case of a failing transaction it indicates if Eventeum should get the revert reason. Currently not working for Ganache and Parity.
 | POLLING_INTERVAL | 10000 | The polling interval used by Web3j to get events from the blockchain. |
 | EVENTSTORE_TYPE | DB | The type of eventstore used in Eventeum. (See the Advanced section for more details) |
 | BROADCASTER_TYPE | KAFKA | The broadcast mechanism to use.  (KAFKA or HTTP or RABBIT) |
-| BROADCASTER_CACHE _EXPIRATIONMILLIS | 6000000 | The eventeum broadcaster has an internal cache of sent messages, which ensures that duplicate messages are not broadcast.  This is the time that a message should live within this cache. |
-| BROADCASTER_EVENT _CONFIRMATION _NUMBLOCKSTOWAIT | 12 | The number of blocks to wait (after the initial mined block) before broadcasting a CONFIRMED event |
-| BROADCASTER_EVENT _CONFIRMATION _NUMBLOCKSTOWAITFORMISSINGTX | 200 | After a fork, a transaction may disappear, and this is the number of blocks to wait on the new fork, before assuming that an event emitted during this transaction has been INVALIDATED |
+| BROADCASTER_CACHE_EXPIRATIONMILLIS | 6000000 | The eventeum broadcaster has an internal cache of sent messages, which ensures that duplicate messages are not broadcast.  This is the time that a message should live within this cache. |
+| BROADCASTER_EVENT_CONFIRMATION_NUMBLOCKSTOWAIT | 12 | The number of blocks to wait (after the initial mined block) before broadcasting a CONFIRMED event |
+| BROADCASTER_EVENT_CONFIRMATION_NUMBLOCKSTOWAITFORMISSINGTX | 200 | After a fork, a transaction may disappear, and this is the number of blocks to wait on the new fork, before assuming that an event emitted during this transaction has been INVALIDATED |
+| BROADCASTER_EVENT_CONFIRMATION_NUMBLOCKSTOWAITBEFOREINVALIDATING | 5 | Number of blocks to wait before considering a block as invalid. |
 | BROADCASTER_MULTIINSTANCE | false | If multiple instances of eventeum are to be deployed in your system, this should be set to true so that the eventeum communicates added/removed filters to other instances, via kafka. |
 | BROADCASTER_HTTP CONTRACTEVENTSURL | | The http url for posting contract events (for HTTP broadcasting) |
 | BROADCASTER_HTTP BLOCKEVENTSURL | | The http url for posting block events (for HTTP broadcasting) |

--- a/README.md
+++ b/README.md
@@ -401,7 +401,7 @@ Eventeum can either be configured by:
 | BROADCASTER_CACHE_EXPIRATIONMILLIS | 6000000 | The eventeum broadcaster has an internal cache of sent messages, which ensures that duplicate messages are not broadcast.  This is the time that a message should live within this cache. |
 | BROADCASTER_EVENT_CONFIRMATION_NUMBLOCKSTOWAIT | 12 | The number of blocks to wait (after the initial mined block) before broadcasting a CONFIRMED event |
 | BROADCASTER_EVENT_CONFIRMATION_NUMBLOCKSTOWAITFORMISSINGTX | 200 | After a fork, a transaction may disappear, and this is the number of blocks to wait on the new fork, before assuming that an event emitted during this transaction has been INVALIDATED |
-| BROADCASTER_EVENT_CONFIRMATION_NUMBLOCKSTOWAITBEFOREINVALIDATING | 5 | Number of blocks to wait before considering a block as invalid. |
+| BROADCASTER_EVENT_CONFIRMATION_NUMBLOCKSTOWAITBEFOREINVALIDATING | 2 | Number of blocks to wait before considering a block as invalid. |
 | BROADCASTER_MULTIINSTANCE | false | If multiple instances of eventeum are to be deployed in your system, this should be set to true so that the eventeum communicates added/removed filters to other instances, via kafka. |
 | BROADCASTER_HTTP CONTRACTEVENTSURL | | The http url for posting contract events (for HTTP broadcasting) |
 | BROADCASTER_HTTP BLOCKEVENTSURL | | The http url for posting block events (for HTTP broadcasting) |

--- a/core/src/main/java/net/consensys/eventeum/chain/config/EventConfirmationConfig.java
+++ b/core/src/main/java/net/consensys/eventeum/chain/config/EventConfirmationConfig.java
@@ -22,11 +22,19 @@ public class EventConfirmationConfig {
     //before an event is considered invalidated
     private BigInteger blocksToWaitForMissingTx;
 
+    //The number of blocks to wait to consider an event invalid because the block
+    //was an invalid block.
+    private BigInteger numBlocksToWaitBeforeInvalidating;
+
     public EventConfirmationConfig(@Value("${broadcaster.event.confirmation.numBlocksToWait}")
                                            BigInteger blocksToWaitForConfirmation,
                                    @Value("${broadcaster.event.confirmation.numBlocksToWaitForMissingTx}")
-                                           BigInteger blocksToWaitForMissingTx) {
+                                           BigInteger blocksToWaitForMissingTx,
+                                   @Value("${broadcaster.event.confirmation.numBlocksToWaitBeforeInvalidating}")
+                                           BigInteger numBlocksToWaitBeforeInvalidating
+    ) {
         this.blocksToWaitForConfirmation = blocksToWaitForConfirmation;
         this.blocksToWaitForMissingTx = blocksToWaitForMissingTx;
+        this.numBlocksToWaitBeforeInvalidating = numBlocksToWaitBeforeInvalidating;
     }
 }

--- a/core/src/main/resources/application.yml
+++ b/core/src/main/resources/application.yml
@@ -66,7 +66,7 @@ broadcaster:
     confirmation:
       numBlocksToWait: 12
       numBlocksToWaitForMissingTx: 100
-      numBlocksToWaitBeforeInvalidating: 5
+      numBlocksToWaitBeforeInvalidating: 2
   multiInstance: false
   bytesToAscii: false
 

--- a/core/src/main/resources/application.yml
+++ b/core/src/main/resources/application.yml
@@ -66,6 +66,7 @@ broadcaster:
     confirmation:
       numBlocksToWait: 12
       numBlocksToWaitForMissingTx: 100
+      numBlocksToWaitBeforeInvalidating: 5
   multiInstance: false
   bytesToAscii: false
 

--- a/core/src/test/java/net/consensys/eventeum/chain/block/EventConfirmationBlockListenerTest.java
+++ b/core/src/test/java/net/consensys/eventeum/chain/block/EventConfirmationBlockListenerTest.java
@@ -81,6 +81,8 @@ public class EventConfirmationBlockListenerTest {
     public void testOnBlockWhenUnderBlockThresholdLogRemoved() {
         wireLog(true, EVENT_BLOCK_HASH, EVENT_LOG_INDEX);
         underTest.onBlock(createBlockDetails(1002));
+        underTest.onBlock(createBlockDetails(1003));
+        underTest.onBlock(createBlockDetails(1004));
 
         expectInvalidation();
     }
@@ -89,6 +91,8 @@ public class EventConfirmationBlockListenerTest {
     public void testOnBlockWhenUnderBlockThresholdBlockHashChanged() {
         wireLog(true, EVENT_BLOCK_HASH + "changed", EVENT_LOG_INDEX);
         underTest.onBlock(createBlockDetails(1002));
+        underTest.onBlock(createBlockDetails(1003));
+        underTest.onBlock(createBlockDetails(1004));
 
         expectInvalidation();
     }
@@ -97,6 +101,8 @@ public class EventConfirmationBlockListenerTest {
     public void testOnBlockWhenUnderBlockThresholdNoMatchingLog() {
         wireLog(true, EVENT_BLOCK_HASH, EVENT_LOG_INDEX.add(BigInteger.ONE));
         underTest.onBlock(createBlockDetails(1002));
+        underTest.onBlock(createBlockDetails(1003));
+        underTest.onBlock(createBlockDetails(1004));
 
         expectInvalidation();
     }
@@ -115,6 +121,7 @@ public class EventConfirmationBlockListenerTest {
 
         underTest.onBlock(createBlockDetails(1005));
         underTest.onBlock(createBlockDetails(1103));
+
         expectNoBroadcast();
     }
 
@@ -124,6 +131,7 @@ public class EventConfirmationBlockListenerTest {
 
         underTest.onBlock(createBlockDetails(1005));
         underTest.onBlock(createBlockDetails(1106));
+
         expectInvalidation();
     }
 

--- a/core/src/test/java/net/consensys/eventeum/chain/block/EventConfirmationBlockListenerTest.java
+++ b/core/src/test/java/net/consensys/eventeum/chain/block/EventConfirmationBlockListenerTest.java
@@ -24,6 +24,7 @@ public class EventConfirmationBlockListenerTest {
 
     private static final BigInteger BLOCKS_TO_WAIT = BigInteger.valueOf(10);
     private static final BigInteger BLOCKS_TO_WAIT_MISSING = BigInteger.valueOf(100);
+    private static final BigInteger BLOCKS_TO_WAIT_BEFORE_INVALIDATING = BigInteger.valueOf(1);
     private static final String EVENT_BLOCK_HASH =
             "0x368ce0ee3afdf1bd73d7e6912f899f31b14b9656e1a3164400ba4587df192c1d";
     private static final BigInteger EVENT_BLOCK_NUMBER = BigInteger.valueOf(1000);
@@ -62,7 +63,7 @@ public class EventConfirmationBlockListenerTest {
         when(mockBlockchainService.getTransactionReceipt(EVENT_TX_HASH)).thenReturn(mockTransactionReceipt);
 
         final EventConfirmationConfig eventConfirmationConfig =
-                new EventConfirmationConfig(BLOCKS_TO_WAIT, BLOCKS_TO_WAIT_MISSING);
+                new EventConfirmationConfig(BLOCKS_TO_WAIT, BLOCKS_TO_WAIT_MISSING, BLOCKS_TO_WAIT_BEFORE_INVALIDATING);
 
         underTest = new EventConfirmationBlockListener(mockEventDetails,
                 mockBlockchainService, mockEventBroadcaster, eventConfirmationConfig, asyncTaskService);

--- a/core/src/test/java/net/consensys/eventeum/chain/contract/ConfirmationCheckInitialiserTest.java
+++ b/core/src/test/java/net/consensys/eventeum/chain/contract/ConfirmationCheckInitialiserTest.java
@@ -41,7 +41,7 @@ public class ConfirmationCheckInitialiserTest {
 
          when(mockNodeServices.getBlockchainService()).thenReturn(mockBlockchainService);
 
-         final EventConfirmationConfig config = new EventConfirmationConfig(BigInteger.TEN, BigInteger.valueOf(100));
+         final EventConfirmationConfig config = new EventConfirmationConfig(BigInteger.TEN, BigInteger.valueOf(100), BigInteger.valueOf(5));
 
          underTest = new ConfirmationCheckInitialiserForTest(mockChainServicesContainer,
                  mock(BlockchainEventBroadcaster.class), config);

--- a/core/src/test/java/net/consensys/eventeum/chain/factory/DefaultContractEventDetailsFactoryTest.java
+++ b/core/src/test/java/net/consensys/eventeum/chain/factory/DefaultContractEventDetailsFactoryTest.java
@@ -158,7 +158,8 @@ public class DefaultContractEventDetailsFactoryTest {
     }
 
     private DefaultContractEventDetailsFactory createFactory(BigInteger confirmations) {
-        final EventConfirmationConfig config = new EventConfirmationConfig(confirmations, BigInteger.valueOf(100));
+        final EventConfirmationConfig config = new EventConfirmationConfig(confirmations, BigInteger.valueOf(100), BigInteger.valueOf(5));
+
         return new DefaultContractEventDetailsFactory(mockParameterCoverter, config, NETWORK_NAME);
     }
 }

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -65,6 +65,7 @@ broadcaster:
     confirmation:
       numBlocksToWait: 12
       numBlocksToWaitForMissingTx: 100
+      numBlocksToWaitBeforeInvalidating: 2
   multiInstance: false
   enableBlockNotifications: true
 


### PR DESCRIPTION
As we have been talking, this introduces the parameter: `numBlocksToWaitBeforeInvalidating` which indicates how many blocks it waits until it invalidates an event because an invalid block. 

This fixes a race condition in infura that comes invalid blocks.  