### PR TITLE
docker-scripts/start-eventeum.sh fix conditional expression

### DIFF
--- a/server/docker-scripts/start-eventeum.sh
+++ b/server/docker-scripts/start-eventeum.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 command="java -jar eventeum-server.jar"
-if [[ -z CONF ]]; then
+if [[ -n CONF ]]; then
   command="$command --spring.config.additional-location=$CONF"
 fi
 


### PR DESCRIPTION
Fix for conditional expression: `-z` => `-n`

I want to use `spring.config.additional-location` for docker image.

`-z STRING`
the length of STRING is zero

` -n STRING`
the length of STRING is nonzero