### PR TITLE
Update maven repository url to https

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <repositories>
         <repository>
             <id>central</id>
-            <url>http://repo1.maven.org/maven2/</url>
+            <url>https://repo1.maven.org/maven2/</url>
         </repository>
         <repository>
             <id>ethereum</id>
@@ -50,7 +50,7 @@
     <pluginRepositories>
         <pluginRepository>
             <id>central</id>
-            <url>http://repo1.maven.org/maven2/</url>
+            <url>https://repo1.maven.org/maven2/</url>
         </pluginRepository>
         <pluginRepository>
             <id>ethereum</id>


### PR DESCRIPTION
Since January 15, builds start failing due to https 501 error. See https://support.sonatype.com/hc/en-us/articles/360041287334.

Error from our circleci logs:
```
 Failed to retrieve POM ... Return code is: 501 , ReasonPhrase:HTTPS Required.
```