### PR TITLE
Fix & clarify dynamically-sized array support documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ Eventeum exposes a REST api that can be used to register events that should be s
 
 Currently supported parameter types: `UINT8-256`, `INT8-256`, `ADDRESS`, `BYTES1-32`, `STRING`, `BOOL`.
 
-Dynamically sized arrays are also supported by prefixing the type with `[]`
+Dynamically sized arrays are also supported by suffixing the type with `[]`, e.g. `UINT256[]`.
 
 **correlationIdStrategy**:
 


### PR DESCRIPTION
- To create an array type, `[]` is _suffixed_ to the base type, not prefixed.
- Gave an example: `UINT256[]`