### PR TITLE
#124 Upgrading lombok and maven-failsafe to become OpenJDK-10+ compatible

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -71,7 +71,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.16.20</version>
+            <version>1.18.2</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -94,7 +94,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.20.1</version>
+                <version>2.22.2</version>
                 <executions>
                     <execution>
                         <id>integration-test</id>


### PR DESCRIPTION
## How to test
- Execute integration test suite:
```bash
$> mvn clean verify -DskipIntegrationTests=false
```

- Execute UnitTest and compile the package
```bash
$> mvn clean package
```

## Additional notes
Details of the machine used to launch the above steps:

```bash
uname -a
Linux ggarrido-laptop 4.15.0-76-generic #86-Ubuntu SMP Fri Jan 17 17:24:28 UTC 2020 x86_64 x86_64 x86_64 GNU/Linux
```

```
$> java --version
openjdk 11.0.6 2020-01-14
OpenJDK Runtime Environment (build 11.0.6+10-post-Ubuntu-1ubuntu118.04.1)
OpenJDK 64-Bit Server VM (build 11.0.6+10-post-Ubuntu-1ubuntu118.04.1, mixed mode, sharing)
```

```
$> mvn --version
Apache Maven 3.6.0
Maven home: /usr/share/maven
Java version: 11.0.6, vendor: Ubuntu, runtime: /usr/lib/jvm/java-11-openjdk-amd64
Default locale: en_US, platform encoding: UTF-8
OS name: "linux", version: "4.15.0-76-generic", arch: "amd64", family: "unix"
```